### PR TITLE
Add /ask command: pinned snippets → Microsoft 365 Copilot → new editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -491,6 +491,7 @@ To target a specific source, prefix your query with a slash command:
 /teams sprint review decisions
 /sharepoint API design document
 /onedrive architecture diagram
+/ask Translate the pinned documents into Japanese as markdown
 ```
 
 ### Building a Handoff from Search Results
@@ -529,6 +530,23 @@ Use the built-in commands to hand off context to GitHub Copilot:
 - **ContextRelay: Copy Handoff Prompt to Clipboard** -- Copies a ready-to-paste Copilot prompt.
 
 Attach `HANDOFF.md` in Copilot Chat using VS Code's context mechanisms (#-mentions / Add Context).
+
+### `/ask` — Process pinned snippets with Microsoft 365 Copilot
+
+Use `/ask` to let **Microsoft 365 Copilot** (not GitHub Copilot) process your currently pinned snippets and write the answer into a brand-new editor tab.
+
+1. Pin one or more documents (`.docx`, SharePoint / OneDrive files, mail, Teams messages). ContextRelay hydrates full document text where possible.
+2. In the chat input, type `/ask` followed by your instruction, for example:
+
+  ```
+  /ask Translate the pinned document into Japanese and output as markdown.
+  /ask Summarize the pinned documents as a bullet list.
+  /ask Extract every action item as JSON with fields owner, due, task.
+  ```
+
+3. ContextRelay sends the pinned content plus your instruction to Microsoft 365 Copilot and opens the response in a new untitled editor. The editor language is auto-detected from the response format (markdown, JSON, HTML, YAML, TypeScript, etc.), so you can save the file with the right extension.
+
+If no snippets are pinned, `/ask` is aborted with a warning. Because this feature relies on the Microsoft 365 Copilot API (preview), you must have a Microsoft 365 Copilot license on the signed-in account and `contextRelay.enableChatPreview` enabled.
 
 To sign out, use the **Accounts** menu in VS Code.
 

--- a/src/adapters/chatAdapter.ts
+++ b/src/adapters/chatAdapter.ts
@@ -48,3 +48,16 @@ export async function sendMessage(
     ?? '';
   return content;
 }
+
+/**
+ * Convenience wrapper that creates a fresh Microsoft 365 Copilot conversation
+ * and sends a single prompt, returning the assistant reply text.
+ */
+export async function askCopilot(token: string, prompt: string): Promise<string> {
+  const conversationId = await createConversation(token);
+  const reply = await sendMessage(token, conversationId, prompt);
+  if (!reply.trim()) {
+    throw new Error('Microsoft 365 Copilot returned an empty response.');
+  }
+  return reply;
+}

--- a/src/panel/askPrompt.ts
+++ b/src/panel/askPrompt.ts
@@ -1,0 +1,45 @@
+import type { SavedSnippet } from '../models/contextItem';
+
+// Upper bound on the combined pinned context we send to Microsoft 365 Copilot.
+// Prevents a runaway prompt when many large documents are pinned.
+export const MAX_ASK_CONTEXT_CHARS = 60_000;
+
+/**
+ * Build the full prompt sent to Microsoft 365 Copilot for /ask.
+ *
+ * Combines the user's instruction with the pinned snippets (already hydrated
+ * with full document content where possible). Individual snippets are
+ * truncated to an equal share of the budget so a single large document
+ * cannot crowd out the others.
+ */
+export function buildAskPrompt(userPrompt: string, snippets: SavedSnippet[]): string {
+  const perSnippetBudget = Math.max(500, Math.floor(MAX_ASK_CONTEXT_CHARS / Math.max(1, snippets.length)));
+
+  const contextBlocks: string[] = [];
+  for (let i = 0; i < snippets.length; i++) {
+    const snippet = snippets[i];
+    const item = snippet.item;
+    const body = (item.snippet ?? '').trim();
+    const truncated = body.length > perSnippetBudget
+      ? `${body.slice(0, perSnippetBudget)}\n…[truncated ${body.length - perSnippetBudget} chars]`
+      : body;
+    const header = [
+      `### Pinned document ${i + 1}: ${snippet.name || item.title}`,
+      `Source: ${item.source}${item.url ? ` — ${item.url}` : ''}`
+    ].join('\n');
+    contextBlocks.push(`${header}\n\n${truncated}`);
+  }
+
+  return [
+    'You are Microsoft 365 Copilot responding inside the VS Code ContextRelay extension.',
+    'Use the pinned documents below as the primary context. Follow the user instruction exactly.',
+    'If the user asks for a specific output format (markdown, JSON, HTML, etc.), produce only that format with no additional commentary.',
+    '',
+    '--- Pinned context ---',
+    contextBlocks.join('\n\n'),
+    '--- End of pinned context ---',
+    '',
+    'User instruction:',
+    userPrompt.trim()
+  ].join('\n');
+}

--- a/src/panel/chatViewProvider.ts
+++ b/src/panel/chatViewProvider.ts
@@ -1,5 +1,6 @@
 import * as crypto from 'crypto';
 import * as vscode from 'vscode';
+import { askCopilot } from '../adapters/chatAdapter';
 import { hydrateItemForHandoff } from '../adapters/handoffContentAdapter';
 import { searchMail } from '../adapters/mailAdapter';
 import { searchRetrieval } from '../adapters/retrievalAdapter';
@@ -10,6 +11,8 @@ import { DocGenerator, type HandoffContext } from '../docs/docGenerator';
 import { type ContextItem, type ContextSource } from '../models/contextItem';
 import { type RouteTarget, getHelpText, parseCommand } from '../router/commandRouter';
 import { SnippetStore } from '../snippets/snippetStore';
+import { buildAskPrompt } from './askPrompt';
+import { detectOutputLanguage } from './outputLanguage';
 import { buildSearchSummary, type SearchSummaryResult } from './searchSummary';
 import { type HostToWebviewMessage, type WebviewToHostMessage } from './types';
 
@@ -211,6 +214,11 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
       return;
     }
 
+    if (parsed.target === 'ask') {
+      await this.handleAskCommand(parsed.query);
+      return;
+    }
+
     const targetSources = this.getTargetSources(parsed.target);
     if (targetSources.length === 0) {
       const message = 'No ContextRelay adapters are enabled.';
@@ -305,17 +313,75 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
     }
   }
 
-  private getTargetSources(target: RouteTarget): ContextSource[] {
-    if (target !== 'all') {
-      return [target];
+  private async handleAskCommand(prompt: string): Promise<void> {
+    const snippets = this.snippetStore.getAll();
+    if (snippets.length === 0) {
+      const message = 'Pin one or more snippets first to use /ask. The pinned content is sent to Microsoft 365 Copilot as context.';
+      vscode.window.showWarningMessage(`ContextRelay: ${message}`);
+      this.postMessage({
+        command: 'queryError',
+        source: 'all',
+        message,
+        timestamp: new Date().toISOString()
+      });
+      return;
     }
 
-    const config = vscode.workspace.getConfiguration('contextRelay');
-    const sources = [...DEFAULT_SOURCES];
-    if (config.get<boolean>('adapters.connectors', false)) {
-      sources.push('connectors');
+    let token: string;
+    try {
+      token = await this.authProvider.getAccessToken();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Authentication required.';
+      this.postMessage({
+        command: 'queryError',
+        source: 'all',
+        message,
+        timestamp: new Date().toISOString()
+      });
+      return;
     }
-    return sources;
+
+    this.postMessage({ command: 'loading', source: 'all', isLoading: true });
+
+    try {
+      const fullPrompt = buildAskPrompt(prompt, snippets);
+      const reply = await askCopilot(token, fullPrompt);
+      const { language, content } = detectOutputLanguage(prompt, reply);
+
+      const doc = await vscode.workspace.openTextDocument({ language, content });
+      await vscode.window.showTextDocument(doc, { preview: false });
+
+      this.postMessage({
+        command: 'assistantMessage',
+        kind: 'ask',
+        text: `Microsoft 365 Copilot response opened in a new editor (${language}). ${snippets.length} pinned snippet(s) used as context.`,
+        timestamp: new Date().toISOString()
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      vscode.window.showErrorMessage(`ContextRelay: /ask failed — ${message}`);
+      this.postMessage({
+        command: 'queryError',
+        source: 'all',
+        message,
+        timestamp: new Date().toISOString()
+      });
+    } finally {
+      this.postMessage({ command: 'loading', source: 'all', isLoading: false });
+    }
+  }
+
+  private getTargetSources(target: RouteTarget): ContextSource[] {
+    if (target === 'ask' || target === 'all') {
+      const config = vscode.workspace.getConfiguration('contextRelay');
+      const sources = [...DEFAULT_SOURCES];
+      if (config.get<boolean>('adapters.connectors', false)) {
+        sources.push('connectors');
+      }
+      return target === 'all' ? sources : [];
+    }
+
+    return [target];
   }
 
   private async fetchResults(
@@ -742,6 +808,7 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
         <h2>ContextRelay</h2>
         <p>Search Microsoft 365 context with slash commands.</p>
         <p style="font-size: 0.8em;">Type <code>/</code> for available commands, or enter a keyword to search all sources.</p>
+        <p style="font-size: 0.8em;">Pin snippets and run <code>/ask</code> to process them with Microsoft 365 Copilot and open the result in a new editor.</p>
       </div>
     </div>
 

--- a/src/panel/outputLanguage.ts
+++ b/src/panel/outputLanguage.ts
@@ -1,0 +1,149 @@
+/**
+ * Heuristics for deciding which editor language to use when opening the
+ * Microsoft 365 Copilot response in a new untitled document.
+ *
+ * The caller passes in both the user prompt and the assistant response.
+ * Detection order:
+ * 1. If the entire response is wrapped in a single fenced code block, use that
+ *    language and return the inner content (fences stripped).
+ * 2. Otherwise, look at the *dominant* fenced language used inside the response.
+ * 3. Otherwise, fall back to keyword hints in the prompt
+ *    (e.g. "markdown", "json", "html").
+ * 4. Default to `markdown`.
+ */
+
+export interface DetectedOutput {
+  language: string;
+  content: string;
+}
+
+interface LanguageEntry {
+  language: string;
+  keywords: readonly string[];
+}
+
+// Keep the list short and aligned with VS Code's known language ids so
+// openTextDocument({ language }) reliably picks a syntax highlighter.
+const KEYWORD_LANGUAGES: readonly LanguageEntry[] = [
+  { language: 'markdown', keywords: ['markdown', 'md format', 'md file', '.md'] },
+  { language: 'json', keywords: ['json'] },
+  { language: 'yaml', keywords: ['yaml', 'yml'] },
+  { language: 'html', keywords: ['html'] },
+  { language: 'xml', keywords: ['xml'] },
+  { language: 'csv', keywords: ['csv'] },
+  { language: 'typescript', keywords: ['typescript', 'tsx'] },
+  { language: 'javascript', keywords: ['javascript', 'jsx'] },
+  { language: 'python', keywords: ['python'] },
+  { language: 'sql', keywords: ['sql'] },
+  { language: 'shellscript', keywords: ['bash', 'shell', 'sh script'] }
+];
+
+const FENCE_ALIASES: Readonly<Record<string, string>> = {
+  md: 'markdown',
+  markdown: 'markdown',
+  json: 'json',
+  yaml: 'yaml',
+  yml: 'yaml',
+  html: 'html',
+  htm: 'html',
+  xml: 'xml',
+  csv: 'csv',
+  ts: 'typescript',
+  tsx: 'typescript',
+  typescript: 'typescript',
+  js: 'javascript',
+  jsx: 'javascript',
+  javascript: 'javascript',
+  py: 'python',
+  python: 'python',
+  sql: 'sql',
+  sh: 'shellscript',
+  bash: 'shellscript',
+  shell: 'shellscript',
+  ps1: 'powershell',
+  powershell: 'powershell',
+  txt: 'plaintext',
+  text: 'plaintext'
+};
+
+function normalizeFenceLanguage(raw: string | undefined): string | undefined {
+  if (!raw) {
+    return undefined;
+  }
+  const key = raw.trim().toLowerCase();
+  if (!key) {
+    return undefined;
+  }
+  return FENCE_ALIASES[key] ?? key;
+}
+
+function stripSingleWrappingFence(response: string): DetectedOutput | undefined {
+  const trimmed = response.trim();
+  // ^```lang\n ... \n```$
+  const match = trimmed.match(/^```([^\n`]*)\n([\s\S]*?)\n```$/);
+  if (!match) {
+    return undefined;
+  }
+  const inner = match[2];
+  // If the inner content itself contains another fenced block, the response
+  // is not just a single wrapped block — treat it as mixed content instead.
+  if (/```/.test(inner)) {
+    return undefined;
+  }
+  const language = normalizeFenceLanguage(match[1]) ?? 'markdown';
+  return { language, content: inner };
+}
+
+function findDominantFenceLanguage(response: string): string | undefined {
+  const counts = new Map<string, number>();
+  const fenceRegex = /```([^\n`]*)\n/g;
+  let m: RegExpExecArray | null;
+  while ((m = fenceRegex.exec(response)) !== null) {
+    const lang = normalizeFenceLanguage(m[1]);
+    if (!lang) {
+      continue;
+    }
+    counts.set(lang, (counts.get(lang) ?? 0) + 1);
+  }
+  if (counts.size === 0) {
+    return undefined;
+  }
+  let best: string | undefined;
+  let bestCount = 0;
+  for (const [lang, count] of counts) {
+    if (count > bestCount) {
+      best = lang;
+      bestCount = count;
+    }
+  }
+  return best;
+}
+
+function findLanguageFromPrompt(prompt: string): string | undefined {
+  const lower = prompt.toLowerCase();
+  for (const entry of KEYWORD_LANGUAGES) {
+    if (entry.keywords.some(keyword => lower.includes(keyword))) {
+      return entry.language;
+    }
+  }
+  return undefined;
+}
+
+export function detectOutputLanguage(prompt: string, response: string): DetectedOutput {
+  const wrapped = stripSingleWrappingFence(response);
+  if (wrapped) {
+    return wrapped;
+  }
+
+  const dominantFence = findDominantFenceLanguage(response);
+  if (dominantFence) {
+    return { language: dominantFence, content: response };
+  }
+
+  const fromPrompt = findLanguageFromPrompt(prompt);
+  if (fromPrompt) {
+    return { language: fromPrompt, content: response };
+  }
+
+  return { language: 'markdown', content: response };
+}

--- a/src/panel/types.ts
+++ b/src/panel/types.ts
@@ -25,6 +25,7 @@ export const SLASH_COMMANDS: SlashCommand[] = [
   { command: '/sharepoint', label: '/sharepoint', description: 'Search SharePoint', icon: '📄', source: 'sharepoint' },
   { command: '/onedrive', label: '/onedrive', description: 'Search OneDrive', icon: '☁️', source: 'onedrive' },
   { command: '/all', label: '/all', description: 'Search all sources', icon: '🔍', source: 'all' },
+  { command: '/ask', label: '/ask', description: 'Ask Microsoft 365 Copilot using pinned snippets as context', icon: '🤖' },
 ];
 
 // --- Messages: Webview → Extension host ---
@@ -99,10 +100,18 @@ export interface ClearChatMessage {
   command: 'clearChat';
 }
 
+export interface AssistantMessage {
+  command: 'assistantMessage';
+  text: string;
+  timestamp: string;
+  kind?: 'info' | 'ask';
+}
+
 export type HostToWebviewMessage =
   | UserMessageDisplay
   | QueryResultMessage
   | QueryErrorMessage
   | LoadingMessage
   | SlashHelpMessage
-  | ClearChatMessage;
+  | ClearChatMessage
+  | AssistantMessage;

--- a/src/router/commandRouter.ts
+++ b/src/router/commandRouter.ts
@@ -1,4 +1,4 @@
-export type RouteTarget = 'mail' | 'teams' | 'sharepoint' | 'onedrive' | 'all';
+export type RouteTarget = 'mail' | 'teams' | 'sharepoint' | 'onedrive' | 'all' | 'ask';
 
 export interface ParsedCommand {
   target: RouteTarget;
@@ -11,7 +11,8 @@ const SLASH_COMMANDS: Record<string, RouteTarget> = {
   teams: 'teams',
   sharepoint: 'sharepoint',
   onedrive: 'onedrive',
-  all: 'all'
+  all: 'all',
+  ask: 'ask'
 };
 
 function normalizeQuery(input: string): string {
@@ -25,8 +26,10 @@ export function parseCommand(input: string): ParsedCommand {
   if (trimmed.startsWith('/')) {
     const commandMatch = trimmed.match(/^\/(\S+)(?:\s+([\s\S]*))?$/);
     const command = commandMatch?.[1]?.toLowerCase() ?? trimmed.slice(1).toLowerCase();
-    const query = normalizeQuery(commandMatch?.[2] ?? '');
+    const rawQuery = commandMatch?.[2] ?? '';
+    // For /ask, preserve newlines in the user's instruction so the prompt keeps its original shape.
     const target = SLASH_COMMANDS[command];
+    const query = target === 'ask' ? rawQuery.trim() : normalizeQuery(rawQuery);
 
     if (target) {
       return { target, query, isEmpty: query.length === 0 };
@@ -44,7 +47,8 @@ export function getHelpText(command: string): string {
     teams: 'Example: /teams sprint review\nExample: /teams from:bob mentions:me',
     sharepoint: 'Example: /sharepoint VPN setup guide\nExample: /sharepoint architecture',
     onedrive: 'Example: /onedrive architecture diagram\nExample: /onedrive Q3 report',
-    all: 'Example: /all architecture decisions\nOr just type a query without a slash command.'
+    all: 'Example: /all architecture decisions\nOr just type a query without a slash command.',
+    ask: 'Example: /ask 日本語に翻訳してmarkdownにして\nExample: /ask Summarize the pinned docs as a bullet list\nPinned snippets are used as context and the Microsoft 365 Copilot response is opened in a new editor tab.'
   };
   return examples[command] ?? 'Type a query to search Microsoft 365 content.';
 }

--- a/src/test/suite/askPrompt.test.ts
+++ b/src/test/suite/askPrompt.test.ts
@@ -1,0 +1,46 @@
+import { strict as assert } from 'assert';
+import { buildAskPrompt } from '../../panel/askPrompt';
+import type { SavedSnippet } from '../../models/contextItem';
+
+function snippet(name: string, body: string): SavedSnippet {
+  return {
+    id: `s-${name}`,
+    name,
+    savedAt: '2024-01-01T00:00:00.000Z',
+    item: {
+      source: 'onedrive',
+      title: name,
+      snippet: body,
+      url: `https://example.com/${name}`,
+      cache: { hit: false }
+    }
+  };
+}
+
+suite('buildAskPrompt', () => {
+  test('includes every pinned snippet with its title and source', () => {
+    const result = buildAskPrompt('translate', [
+      snippet('doc-a.docx', 'Hello world'),
+      snippet('doc-b.docx', 'Second document body')
+    ]);
+
+    assert.ok(result.includes('Pinned document 1: doc-a.docx'));
+    assert.ok(result.includes('Hello world'));
+    assert.ok(result.includes('Pinned document 2: doc-b.docx'));
+    assert.ok(result.includes('Second document body'));
+    assert.ok(result.includes('User instruction:'));
+    assert.ok(result.trimEnd().endsWith('translate'));
+  });
+
+  test('truncates snippets that exceed the per-snippet budget', () => {
+    const huge = 'x'.repeat(200_000);
+    const result = buildAskPrompt('summarize', [snippet('big.txt', huge)]);
+    assert.ok(result.includes('[truncated'), 'expected truncation marker');
+    assert.ok(result.length < 200_000 + 2000);
+  });
+
+  test('references Microsoft 365 Copilot as the responder', () => {
+    const result = buildAskPrompt('hi', [snippet('a', 'b')]);
+    assert.ok(result.toLowerCase().includes('microsoft 365 copilot'));
+  });
+});

--- a/src/test/suite/commandRouter.test.ts
+++ b/src/test/suite/commandRouter.test.ts
@@ -94,4 +94,22 @@ suite('CommandRouter', () => {
     const text = getHelpText('unknown');
     assert.ok(text.length > 0);
   });
+
+  test('/ask command routes to ask and preserves newlines in the query', () => {
+    const result = parseCommand('/ask translate to Japanese\nand output as markdown');
+    assert.equal(result.target, 'ask');
+    assert.equal(result.query, 'translate to Japanese\nand output as markdown');
+    assert.equal(result.isEmpty, false);
+  });
+
+  test('empty /ask triggers isEmpty for slash help', () => {
+    const result = parseCommand('/ask');
+    assert.equal(result.target, 'ask');
+    assert.equal(result.isEmpty, true);
+  });
+
+  test('getHelpText for ask mentions Microsoft 365 Copilot', () => {
+    const text = getHelpText('ask');
+    assert.ok(text.toLowerCase().includes('microsoft 365 copilot'));
+  });
 });

--- a/src/test/suite/outputLanguage.test.ts
+++ b/src/test/suite/outputLanguage.test.ts
@@ -1,0 +1,49 @@
+import { strict as assert } from 'assert';
+import { detectOutputLanguage } from '../../panel/outputLanguage';
+
+suite('detectOutputLanguage', () => {
+  test('strips a single wrapping fenced block and uses its language', () => {
+    const response = '```json\n{"a":1}\n```';
+    const result = detectOutputLanguage('convert to json', response);
+    assert.equal(result.language, 'json');
+    assert.equal(result.content, '{"a":1}');
+  });
+
+  test('maps md alias to markdown', () => {
+    const response = '```md\n# Title\n\nBody\n```';
+    const result = detectOutputLanguage('make it a markdown file', response);
+    assert.equal(result.language, 'markdown');
+    assert.equal(result.content, '# Title\n\nBody');
+  });
+
+  test('does not strip fences when the response contains multiple blocks', () => {
+    const response = 'Intro\n\n```ts\nconst a = 1;\n```\n\n```ts\nconst b = 2;\n```';
+    const result = detectOutputLanguage('explain', response);
+    assert.equal(result.language, 'typescript');
+    assert.equal(result.content, response);
+  });
+
+  test('picks dominant inner fence language when response is mixed content', () => {
+    const response = 'Here is the data:\n\n```yaml\nkey: value\n```\n\nDone.';
+    const result = detectOutputLanguage('do the thing', response);
+    assert.equal(result.language, 'yaml');
+    assert.equal(result.content, response);
+  });
+
+  test('falls back to prompt keyword when no fenced block is present', () => {
+    const result = detectOutputLanguage('translate to Japanese and return as HTML', 'Plain text reply.');
+    assert.equal(result.language, 'html');
+    assert.equal(result.content, 'Plain text reply.');
+  });
+
+  test('defaults to markdown when nothing else matches', () => {
+    const result = detectOutputLanguage('translate to Japanese', 'Plain text reply.');
+    assert.equal(result.language, 'markdown');
+    assert.equal(result.content, 'Plain text reply.');
+  });
+
+  test('markdown keyword in prompt wins over default', () => {
+    const result = detectOutputLanguage('please give me markdown output', 'no fences here');
+    assert.equal(result.language, 'markdown');
+  });
+});

--- a/src/webview/chatRenderer.ts
+++ b/src/webview/chatRenderer.ts
@@ -97,6 +97,32 @@ export class ChatRenderer {
   }
 
   /**
+   * Render a plain assistant text message (used by /ask for status updates).
+   */
+  renderAssistantMessage(text: string, timestamp: string): void {
+    this.hideWelcome();
+
+    const el = document.createElement('div');
+    el.className = 'message assistant';
+    el.setAttribute('role', 'article');
+
+    const textDiv = document.createElement('div');
+    textDiv.textContent = text;
+    el.appendChild(textDiv);
+
+    const timeStr = this.formatTime(timestamp);
+    if (timeStr) {
+      const tsDiv = document.createElement('div');
+      tsDiv.className = 'timestamp';
+      tsDiv.textContent = timeStr;
+      el.appendChild(tsDiv);
+    }
+
+    this.chatArea.appendChild(el);
+    this.scrollToBottom();
+  }
+
+  /**
    * Render query results as an assistant message with result cards.
    */
   renderQueryResult(
@@ -239,6 +265,7 @@ export class ChatRenderer {
       <h2>ContextRelay</h2>
       <p>Search Microsoft 365 context with slash commands.</p>
       <p style="font-size: 0.8em;">Type <code>/</code> for available commands, or enter a keyword to search all sources.</p>
+      <p style="font-size: 0.8em;">Pin snippets and run <code>/ask</code> to process them with Microsoft 365 Copilot.</p>
     `;
     this.chatArea.appendChild(welcome);
     this.welcomeEl = welcome;

--- a/src/webview/main.ts
+++ b/src/webview/main.ts
@@ -161,5 +161,12 @@ window.addEventListener('message', (event) => {
     case 'clearChat':
       renderer.clear();
       break;
+
+    case 'assistantMessage':
+      renderer.renderAssistantMessage(
+        message.text as string,
+        message.timestamp as string
+      );
+      break;
   }
 });

--- a/src/webview/slashMenu.ts
+++ b/src/webview/slashMenu.ts
@@ -16,6 +16,7 @@ const SLASH_ITEMS: SlashMenuItem[] = [
   { command: '/sharepoint', label: '/sharepoint', description: 'Search SharePoint', icon: '📄' },
   { command: '/onedrive', label: '/onedrive', description: 'Search OneDrive', icon: '☁️' },
   { command: '/all', label: '/all', description: 'Search all sources', icon: '🔍' },
+  { command: '/ask', label: '/ask', description: 'Ask Microsoft 365 Copilot using pinned snippets', icon: '🤖' },
 ];
 
 export class SlashMenu {


### PR DESCRIPTION
## Why

ContextRelay already lets users pin Microsoft 365 documents (mail, Teams, SharePoint, OneDrive, docx files with full-text hydration), but there was no way to *act* on them inside VS Code. Users had to copy content out, paste it into another tool, and bring the result back. This PR closes that loop by letting pinned snippets be processed by **Microsoft 365 Copilot** (not GitHub Copilot) and writing the result directly into a new editor tab.

Example workflow: pin an English `.docx`, type `/ask 日本語に翻訳してmarkdownにして`, and a new untitled markdown editor opens with the translation.

## Approach

- **New slash command `/ask`** routed through `commandRouter`. Unlike search commands it preserves newlines so multi-line instructions survive the round trip.
- **`askPrompt.ts`** builds the Copilot prompt: every pinned snippet becomes a `### Pinned document N` block with title/source header and the already-hydrated body. A `MAX_ASK_CONTEXT_CHARS = 60000` budget is divided evenly across pinned items so one huge document cannot crowd the others out; oversized bodies are truncated with a visible `[truncated N chars]` marker.
- **`chatAdapter.askCopilot`** reuses the existing preview `graph.microsoft.com/beta/copilot/conversations` integration (createConversation + sendMessage), so this rides on top of the already-wired Microsoft 365 Copilot API path — no new endpoint surface.
- **`outputLanguage.ts`** auto-detects the target editor language from the response: unwrap a single wrapping fenced block, otherwise take the dominant inner fence language, otherwise scan the user's prompt for format keywords (markdown/json/yaml/html/xml/csv/ts/js/py/sql/shell), otherwise default to `markdown`. If the response is a single fence, the fence is stripped so the editor content is clean.
- **`chatViewProvider.handleAskCommand`** glues it together: warn + abort if zero snippets pinned, acquire auth token, call `askCopilot`, run language detection, open the result via `vscode.workspace.openTextDocument({ language, content })` as an untitled editor, and surface progress via a new `assistantMessage` webview channel.
- **Webview**: `/ask` is now listed in the slash menu; `chatRenderer` gains `renderAssistantMessage` for host-originated status text; the welcome card mentions the new workflow.

## Notable details

- The output editor is intentionally **untitled** so the user picks where to save it — this matches the "new markdown file in editor" spirit of the feature without guessing filenames.
- Microsoft 365 Copilot API is still in preview (`contextRelay.enableChatPreview`); a missing license surfaces through the existing `CopilotLicenseRequired` handling in `graphClient.ts`.
- `buildAskPrompt` was extracted into its own module (`src/panel/askPrompt.ts`) rather than staying inside `chatViewProvider.ts` so it is unit-testable without pulling in the `vscode` namespace.

## Validation

All four required gates pass:

- `npm run compile` — clean
- `npm run lint` — 0 errors, 0 warnings
- `npm test` — **74 passing** (13 new tests across `outputLanguage.test.ts`, `askPrompt.test.ts`, and `/ask` cases added to `commandRouter.test.ts`)
- `npm run security:check` — 0 vulnerabilities

## Docs

README gains an `/ask` section with translation / summarization / JSON-extraction examples, plus the command in the slash-command list.