### PR TITLE
Fix Copilot review feedback for /ask

### DIFF
--- a/src/panel/askPrompt.ts
+++ b/src/panel/askPrompt.ts
@@ -21,7 +21,15 @@ function truncateToBudget(body: string, budget: number): string {
     }
   }
 
-  return body.slice(0, budget);
+  // Budget is too small to fit both a prefix and the truncation suffix.
+  // Return the marker (possibly itself truncated) so the caller always knows
+  // content was omitted rather than silently returning raw untagged content.
+  const markerOnly = `\n…[truncated ${body.length} chars]`;
+  if (markerOnly.length <= budget) {
+    return markerOnly;
+  }
+
+  return markerOnly.slice(0, budget);
 }
 
 /**
@@ -55,7 +63,7 @@ export function buildAskPrompt(userPrompt: string, snippets: SavedSnippet[]): st
 
     const truncated = truncateToBudget(body, remainingContextBudget - fixedCost);
     const block = `${separator}${blockPrefix}${truncated}`;
-    contextBlocks.push(`${header}\n\n${truncated}`);
+    contextBlocks.push(block);
     remainingContextBudget -= block.length;
   }
 
@@ -65,7 +73,7 @@ export function buildAskPrompt(userPrompt: string, snippets: SavedSnippet[]): st
     'If the user asks for a specific output format (markdown, JSON, HTML, etc.), produce only that format with no additional commentary.',
     '',
     '--- Pinned context ---',
-    contextBlocks.join('\n\n'),
+    contextBlocks.join(''),
     '--- End of pinned context ---',
     '',
     'User instruction:',

--- a/src/panel/askPrompt.ts
+++ b/src/panel/askPrompt.ts
@@ -4,30 +4,59 @@ import type { SavedSnippet } from '../models/contextItem';
 // Prevents a runaway prompt when many large documents are pinned.
 export const MAX_ASK_CONTEXT_CHARS = 60_000;
 
+function truncateToBudget(body: string, budget: number): string {
+  if (budget <= 0) {
+    return '';
+  }
+
+  if (body.length <= budget) {
+    return body;
+  }
+
+  for (let prefixLength = Math.min(body.length, budget); prefixLength > 0; prefixLength--) {
+    const omittedChars = body.length - prefixLength;
+    const suffix = `\n…[truncated ${omittedChars} chars]`;
+    if (prefixLength + suffix.length <= budget) {
+      return `${body.slice(0, prefixLength)}${suffix}`;
+    }
+  }
+
+  return body.slice(0, budget);
+}
+
 /**
  * Build the full prompt sent to Microsoft 365 Copilot for /ask.
  *
  * Combines the user's instruction with the pinned snippets (already hydrated
- * with full document content where possible). Individual snippets are
- * truncated to an equal share of the budget so a single large document
- * cannot crowd out the others.
+ * with full document content where possible). The combined pinned context is
+ * capped by MAX_ASK_CONTEXT_CHARS so a large number of snippets cannot cause
+ * the prompt to grow without bound.
  */
 export function buildAskPrompt(userPrompt: string, snippets: SavedSnippet[]): string {
-  const perSnippetBudget = Math.max(500, Math.floor(MAX_ASK_CONTEXT_CHARS / Math.max(1, snippets.length)));
-
   const contextBlocks: string[] = [];
-  for (let i = 0; i < snippets.length; i++) {
+  let remainingContextBudget = MAX_ASK_CONTEXT_CHARS;
+
+  for (let i = 0; i < snippets.length && remainingContextBudget > 0; i++) {
     const snippet = snippets[i];
     const item = snippet.item;
     const body = (item.snippet ?? '').trim();
-    const truncated = body.length > perSnippetBudget
-      ? `${body.slice(0, perSnippetBudget)}\n…[truncated ${body.length - perSnippetBudget} chars]`
-      : body;
     const header = [
       `### Pinned document ${i + 1}: ${snippet.name || item.title}`,
       `Source: ${item.source}${item.url ? ` — ${item.url}` : ''}`
     ].join('\n');
+
+    const separator = contextBlocks.length > 0 ? '\n\n' : '';
+    const blockPrefix = `${header}\n\n`;
+    const fixedCost = separator.length + blockPrefix.length;
+
+    if (fixedCost >= remainingContextBudget) {
+      break;
+    }
+
+    const truncated = truncateToBudget(body, remainingContextBudget - fixedCost);
+    const block = `${separator}${blockPrefix}${truncated}`;
     contextBlocks.push(`${header}\n\n${truncated}`);
+    remainingContextBudget -= block.length;
   }
 
   return [

--- a/src/panel/outputLanguage.ts
+++ b/src/panel/outputLanguage.ts
@@ -79,8 +79,8 @@ function normalizeFenceLanguage(raw: string | undefined): string | undefined {
 
 function stripSingleWrappingFence(response: string): DetectedOutput | undefined {
   const trimmed = response.trim();
-  // ^```lang\n ... \n```$
-  const match = trimmed.match(/^```([^\n`]*)\n([\s\S]*?)\n```$/);
+  // ^```lang\r?\n ... \r?\n```$
+  const match = trimmed.match(/^```([^\r\n`]*)\r?\n([\s\S]*?)\r?\n```$/);
   if (!match) {
     return undefined;
   }
@@ -96,7 +96,7 @@ function stripSingleWrappingFence(response: string): DetectedOutput | undefined 
 
 function findDominantFenceLanguage(response: string): string | undefined {
   const counts = new Map<string, number>();
-  const fenceRegex = /```([^\n`]*)\n/g;
+  const fenceRegex = /```([^\r\n`]*)\r?\n/g;
   let m: RegExpExecArray | null;
   while ((m = fenceRegex.exec(response)) !== null) {
     const lang = normalizeFenceLanguage(m[1]);

--- a/src/test/suite/askPrompt.test.ts
+++ b/src/test/suite/askPrompt.test.ts
@@ -1,5 +1,5 @@
 import { strict as assert } from 'assert';
-import { buildAskPrompt } from '../../panel/askPrompt';
+import { buildAskPrompt, MAX_ASK_CONTEXT_CHARS } from '../../panel/askPrompt';
 import type { SavedSnippet } from '../../models/contextItem';
 
 function snippet(name: string, body: string): SavedSnippet {
@@ -42,5 +42,22 @@ suite('buildAskPrompt', () => {
   test('references Microsoft 365 Copilot as the responder', () => {
     const result = buildAskPrompt('hi', [snippet('a', 'b')]);
     assert.ok(result.toLowerCase().includes('microsoft 365 copilot'));
+  });
+
+  test('caps combined pinned context even with many snippets', () => {
+    const snippets = Array.from({ length: 200 }, (_, index) =>
+      snippet(`doc-${index}.txt`, 'x'.repeat(1_000))
+    );
+
+    const result = buildAskPrompt('summarize', snippets);
+    const start = result.indexOf('--- Pinned context ---\n');
+    const end = result.indexOf('\n--- End of pinned context ---');
+
+    assert.notEqual(start, -1);
+    assert.notEqual(end, -1);
+
+    const context = result.slice(start + '--- Pinned context ---\n'.length, end);
+    assert.ok(context.length <= MAX_ASK_CONTEXT_CHARS);
+    assert.ok(context.includes('[truncated'));
   });
 });

--- a/src/test/suite/outputLanguage.test.ts
+++ b/src/test/suite/outputLanguage.test.ts
@@ -16,6 +16,13 @@ suite('detectOutputLanguage', () => {
     assert.equal(result.content, '# Title\n\nBody');
   });
 
+  test('strips a single wrapping fenced block with CRLF line endings', () => {
+    const response = '```json\r\n{"a":1}\r\n```';
+    const result = detectOutputLanguage('convert to json', response);
+    assert.equal(result.language, 'json');
+    assert.equal(result.content, '{"a":1}');
+  });
+
   test('does not strip fences when the response contains multiple blocks', () => {
     const response = 'Intro\n\n```ts\nconst a = 1;\n```\n\n```ts\nconst b = 2;\n```';
     const result = detectOutputLanguage('explain', response);
@@ -25,6 +32,13 @@ suite('detectOutputLanguage', () => {
 
   test('picks dominant inner fence language when response is mixed content', () => {
     const response = 'Here is the data:\n\n```yaml\nkey: value\n```\n\nDone.';
+    const result = detectOutputLanguage('do the thing', response);
+    assert.equal(result.language, 'yaml');
+    assert.equal(result.content, response);
+  });
+
+  test('picks dominant inner fence language with CRLF line endings', () => {
+    const response = 'Here is the data:\r\n\r\n```yaml\r\nkey: value\r\n```\r\n\r\nDone.';
     const result = detectOutputLanguage('do the thing', response);
     assert.equal(result.language, 'yaml');
     assert.equal(result.content, response);


### PR DESCRIPTION
This pull request improves the handling of context truncation in the `/ask` prompt builder and enhances support for code fences with CRLF line endings in output language detection. It introduces more robust logic for capping the combined context length and ensures that code block parsing works correctly regardless of line ending style. Corresponding tests have been added to validate these behaviors.

**Prompt building and context truncation:**
- Refactored `buildAskPrompt` in `askPrompt.ts` to cap the combined pinned context by `MAX_ASK_CONTEXT_CHARS`, ensuring that an excessive number of snippets cannot cause runaway prompt size. The truncation logic now dynamically allocates remaining budget per snippet, and a helper function `truncateToBudget` was introduced for more precise truncation.
- Added a test to verify that the combined context is capped even with many snippets and that truncation is indicated in the output.

**Code fence handling and output language detection:**
- Updated regexes in `outputLanguage.ts` to correctly parse code fences with both LF and CRLF line endings, improving compatibility with Windows-style files. [[1]](diffhunk://#diff-3d61dd6242ef6873174661e41427017569d1b34668b76d69a1e9b41ce3965ac0L82-R83) [[2]](diffhunk://#diff-3d61dd6242ef6873174661e41427017569d1b34668b76d69a1e9b41ce3965ac0L99-R99)
- Added tests to ensure that code fences with CRLF endings are stripped or detected correctly, including for dominant language detection. [[1]](diffhunk://#diff-182e85a9299e32c6573157d360d23fa749cf4c196f16e3bf205f4a5c26aeb852R19-R25) [[2]](diffhunk://#diff-182e85a9299e32c6573157d360d23fa749cf4c196f16e3bf205f4a5c26aeb852R40-R46)

**Test improvements:**
- Updated test imports in `askPrompt.test.ts` to include `MAX_ASK_CONTEXT_CHARS` for use in new assertions.