### PR TITLE
Suppress Extension Host punycode deprecation warning

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,4 +1,4 @@
-import './suppressPunycodeDeprecation';
+import './suppressPunycodeDeprecation.install';
 import * as vscode from 'vscode';
 import * as fs from 'fs';
 import { ChatViewProvider } from './panel/chatViewProvider';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,3 +1,4 @@
+import './suppressPunycodeDeprecation';
 import * as vscode from 'vscode';
 import * as fs from 'fs';
 import { ChatViewProvider } from './panel/chatViewProvider';

--- a/src/suppressPunycodeDeprecation.install.ts
+++ b/src/suppressPunycodeDeprecation.install.ts
@@ -1,0 +1,6 @@
+// Side-effect entry: installs the punycode deprecation filter immediately.
+// Import this as the very first import in `extension.ts` so the patch is
+// active before any other module is evaluated.
+import { installPunycodeDeprecationFilter } from './suppressPunycodeDeprecation';
+
+installPunycodeDeprecationFilter();

--- a/src/suppressPunycodeDeprecation.ts
+++ b/src/suppressPunycodeDeprecation.ts
@@ -1,13 +1,12 @@
-// Side-effect module that suppresses Node.js DEP0040
-// ("The `punycode` module is deprecated. Please use a userland alternative instead.").
+// Pure module that exports `installPunycodeDeprecationFilter`.
+// It does NOT install the filter at import time — call the function explicitly,
+// or import the side-effect entry `suppressPunycodeDeprecation.install.ts`.
 //
-// Our extension does not `require('punycode')` itself, but the VS Code
-// Extension Host / other modules loaded in the same Node process may, and the
-// resulting warning is noisy in the Debug Console. We filter only DEP0040 and
-// leave all other warnings untouched.
-//
-// Import this module as the very first import in `extension.ts` so the patch
-// is installed before any other module evaluates.
+// The filter suppresses the Node.js DEP0040 ("The `punycode` module is
+// deprecated") warning. A warning is dropped when EITHER:
+//   - its explicit code is 'DEP0040', OR
+//   - no code is provided and the message text matches the punycode pattern.
+// All other warnings are forwarded to the original `process.emitWarning`.
 
 type EmitWarning = typeof process.emitWarning;
 
@@ -64,5 +63,3 @@ export function installPunycodeDeprecationFilter(): void {
   patched.__contextRelayPunycodePatch = true;
   process.emitWarning = patched;
 }
-
-installPunycodeDeprecationFilter();

--- a/src/suppressPunycodeDeprecation.ts
+++ b/src/suppressPunycodeDeprecation.ts
@@ -1,0 +1,68 @@
+// Side-effect module that suppresses Node.js DEP0040
+// ("The `punycode` module is deprecated. Please use a userland alternative instead.").
+//
+// Our extension does not `require('punycode')` itself, but the VS Code
+// Extension Host / other modules loaded in the same Node process may, and the
+// resulting warning is noisy in the Debug Console. We filter only DEP0040 and
+// leave all other warnings untouched.
+//
+// Import this module as the very first import in `extension.ts` so the patch
+// is installed before any other module evaluates.
+
+type EmitWarning = typeof process.emitWarning;
+
+interface PatchedEmitWarning extends EmitWarning {
+  __contextRelayPunycodePatch?: true;
+}
+
+function isPunycodeDeprecation(
+  warning: string | Error,
+  typeOrOptions?: string | (NodeJS.EmitWarningOptions | undefined),
+  code?: string
+): boolean {
+  const explicitCode =
+    code ??
+    (typeof typeOrOptions === 'object' && typeOrOptions !== null
+      ? typeOrOptions.code
+      : undefined);
+
+  if (explicitCode === 'DEP0040') {
+    return true;
+  }
+
+  const message = typeof warning === 'string' ? warning : warning?.message ?? '';
+  return /\bpunycode\b[^\n]*\bdeprecated\b/i.test(message);
+}
+
+export function installPunycodeDeprecationFilter(): void {
+  const current = process.emitWarning as PatchedEmitWarning;
+  if (current.__contextRelayPunycodePatch) {
+    return;
+  }
+
+  const original = current.bind(process) as EmitWarning;
+
+  const patched: PatchedEmitWarning = function emitWarning(
+    this: unknown,
+    warning: string | Error,
+    typeOrOptions?: string | NodeJS.EmitWarningOptions,
+    code?: string,
+    ctor?: (...args: unknown[]) => unknown
+  ): void {
+    if (isPunycodeDeprecation(warning, typeOrOptions, code)) {
+      return;
+    }
+    // Delegate to the original implementation preserving all overloads.
+    return (original as (...a: unknown[]) => void)(
+      warning,
+      typeOrOptions as never,
+      code as never,
+      ctor as never
+    );
+  } as PatchedEmitWarning;
+
+  patched.__contextRelayPunycodePatch = true;
+  process.emitWarning = patched;
+}
+
+installPunycodeDeprecationFilter();

--- a/src/test/suite/suppressPunycodeDeprecation.test.ts
+++ b/src/test/suite/suppressPunycodeDeprecation.test.ts
@@ -1,0 +1,79 @@
+import { strict as assert } from 'assert';
+import { installPunycodeDeprecationFilter } from '../../suppressPunycodeDeprecation';
+
+suite('suppressPunycodeDeprecation', () => {
+  let original: typeof process.emitWarning;
+
+  setup(() => {
+    original = process.emitWarning;
+  });
+
+  teardown(() => {
+    process.emitWarning = original;
+  });
+
+  test('drops warnings with code DEP0040', () => {
+    const captured: Array<unknown[]> = [];
+    process.emitWarning = ((...args: unknown[]) => {
+      captured.push(args);
+    }) as typeof process.emitWarning;
+
+    installPunycodeDeprecationFilter();
+
+    process.emitWarning(
+      'The `punycode` module is deprecated. Please use a userland alternative instead.',
+      'DeprecationWarning',
+      'DEP0040'
+    );
+
+    assert.equal(captured.length, 0, 'DEP0040 warnings must be suppressed');
+  });
+
+  test('drops punycode deprecation message without explicit code', () => {
+    const captured: Array<unknown[]> = [];
+    process.emitWarning = ((...args: unknown[]) => {
+      captured.push(args);
+    }) as typeof process.emitWarning;
+
+    installPunycodeDeprecationFilter();
+
+    process.emitWarning(
+      'The `punycode` module is deprecated. Please use a userland alternative instead.'
+    );
+
+    assert.equal(captured.length, 0, 'punycode deprecation message must be suppressed');
+  });
+
+  test('passes through unrelated warnings', () => {
+    const captured: Array<unknown[]> = [];
+    process.emitWarning = ((...args: unknown[]) => {
+      captured.push(args);
+    }) as typeof process.emitWarning;
+
+    installPunycodeDeprecationFilter();
+
+    process.emitWarning('Something else is happening', 'Warning', 'WRN0001');
+    process.emitWarning(new Error('another issue'));
+
+    assert.equal(captured.length, 2, 'unrelated warnings must pass through');
+    assert.equal(captured[0][0], 'Something else is happening');
+    assert.equal((captured[1][0] as Error).message, 'another issue');
+  });
+
+  test('is idempotent across multiple installations', () => {
+    const captured: Array<unknown[]> = [];
+    process.emitWarning = ((...args: unknown[]) => {
+      captured.push(args);
+    }) as typeof process.emitWarning;
+
+    installPunycodeDeprecationFilter();
+    const afterFirst = process.emitWarning;
+    installPunycodeDeprecationFilter();
+    const afterSecond = process.emitWarning;
+
+    assert.strictEqual(afterFirst, afterSecond, 'filter must not be re-wrapped');
+
+    process.emitWarning('benign', 'Warning', 'OK0001');
+    assert.equal(captured.length, 1);
+  });
+});


### PR DESCRIPTION
## Why
Launching the extension in the Extension Development Host shows Node.js DEP0040 for `punycode`, even though the extension bundle does not depend on that module directly. The warning is noisy in the debug console and makes normal extension startup look unhealthy.

Closes #8.

## What changed
This adds a small side-effect module that installs a targeted `process.emitWarning` filter before the rest of the extension loads. The filter suppresses only the `punycode` deprecation warning (DEP0040 or the matching warning text) and leaves all other warnings untouched.

The filter is imported first from `extension.ts` so it is active before other modules are evaluated, and tests cover the non-obvious behavior: suppressing DEP0040, matching the message without an explicit code, preserving unrelated warnings, and avoiding double wrapping.

## Notes for review
The warning appears to come from the VS Code Extension Host process or another module loaded into that process, not from the extension's runtime bundle. This change intentionally addresses the host-facing symptom without muting any broader warning surface.

## Validation
- `npm run compile`
- `npm run lint`
- `npm test`
- `npm run security:check`