### PR TITLE
Toggle 📌 indicator on search result cards when pinning

### DIFF
--- a/src/models/contextItem.ts
+++ b/src/models/contextItem.ts
@@ -31,3 +31,11 @@ export interface SavedSnippet {
   name: string;
   savedAt: string;
 }
+
+/**
+ * Build a stable key for a context item so the UI and the snippet store
+ * agree on whether two items are "the same" for pin toggling.
+ */
+export function getContextItemKey(item: Pick<ContextItem, 'source' | 'title' | 'url'>): string {
+  return `${item.source}::${item.url ?? ''}::${item.title}`;
+}

--- a/src/models/contextItem.ts
+++ b/src/models/contextItem.ts
@@ -36,6 +36,14 @@ export interface SavedSnippet {
  * Build a stable key for a context item so the UI and the snippet store
  * agree on whether two items are "the same" for pin toggling.
  */
-export function getContextItemKey(item: Pick<ContextItem, 'source' | 'title' | 'url'>): string {
-  return `${item.source}::${item.url ?? ''}::${item.title}`;
+export function getContextItemKey(
+  item: Pick<ContextItem, 'source' | 'title' | 'url' | 'timestamp' | 'snippet'>
+): string {
+  const discriminator =
+    item.url?.trim() ||
+    item.timestamp?.trim() ||
+    item.snippet.trim() ||
+    '';
+
+  return `${item.source}::${discriminator}::${item.title}`;
 }

--- a/src/panel/chatViewProvider.ts
+++ b/src/panel/chatViewProvider.ts
@@ -8,7 +8,7 @@ import { searchTeams } from '../adapters/teamsAdapter';
 import { AuthProvider } from '../auth/authProvider';
 import { CacheStore } from '../cache/cacheStore';
 import { DocGenerator, type HandoffContext } from '../docs/docGenerator';
-import { type ContextItem, type ContextSource } from '../models/contextItem';
+import { type ContextItem, type ContextSource, getContextItemKey } from '../models/contextItem';
 import { type RouteTarget, getHelpText, parseCommand } from '../router/commandRouter';
 import { SnippetStore } from '../snippets/snippetStore';
 import { buildAskPrompt } from './askPrompt';
@@ -102,6 +102,7 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
 
   public clearSnippets(): void {
     this.snippetStore.clear();
+    this.sendPinnedItems();
   }
 
   public getDocGenerator(): DocGenerator {
@@ -132,6 +133,7 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
       case 'webviewReady':
         this.webviewReady = true;
         this.flushPendingMessages();
+        this.sendPinnedItems();
         break;
       case 'submitQuery':
         await this.handleQuery(message.text);
@@ -169,6 +171,15 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
   }
 
   private async handlePinSnippet(item: ContextItem): Promise<void> {
+    const key = getContextItemKey(item);
+
+    // Toggle: if this item is already pinned, unpin it instead of saving again.
+    if (this.snippetStore.removeByItemKey(key)) {
+      this.sendPinnedItems();
+      vscode.window.showInformationMessage(`Snippet "${item.title}" unpinned.`);
+      return;
+    }
+
     let handoffItem = item;
 
     if (item.source === 'mail' || item.source === 'sharepoint' || item.source === 'onedrive') {
@@ -183,7 +194,15 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
     }
 
     const snippet = this.snippetStore.save(handoffItem);
+    this.sendPinnedItems();
     vscode.window.showInformationMessage(`Snippet "${snippet.name}" saved.`);
+  }
+
+  private sendPinnedItems(): void {
+    this.postMessage({
+      command: 'pinnedItems',
+      keys: this.snippetStore.getPinnedKeys()
+    });
   }
 
   private async handleQuery(text: string): Promise<void> {

--- a/src/panel/types.ts
+++ b/src/panel/types.ts
@@ -107,6 +107,11 @@ export interface AssistantMessage {
   kind?: 'info' | 'ask';
 }
 
+export interface PinnedItemsMessage {
+  command: 'pinnedItems';
+  keys: string[];
+}
+
 export type HostToWebviewMessage =
   | UserMessageDisplay
   | QueryResultMessage
@@ -114,4 +119,5 @@ export type HostToWebviewMessage =
   | LoadingMessage
   | SlashHelpMessage
   | ClearChatMessage
-  | AssistantMessage;
+  | AssistantMessage
+  | PinnedItemsMessage;

--- a/src/snippets/snippetStore.ts
+++ b/src/snippets/snippetStore.ts
@@ -17,10 +17,6 @@ export class SnippetStore {
     return this.getAll().map(s => getContextItemKey(s.item));
   }
 
-  findByItemKey(key: string): SavedSnippet | undefined {
-    return this.getAll().find(s => getContextItemKey(s.item) === key);
-  }
-
   save(item: ContextItem, name?: string): SavedSnippet {
     const snippets = this.getAll();
     const id = `snippet-${Date.now()}-${Math.random().toString(36).slice(2)}`;

--- a/src/snippets/snippetStore.ts
+++ b/src/snippets/snippetStore.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { SavedSnippet, ContextItem } from '../models/contextItem';
+import { SavedSnippet, ContextItem, getContextItemKey } from '../models/contextItem';
 
 const WORKSPACE_STATE_KEY = 'contextRelay.snippets';
 
@@ -8,6 +8,17 @@ export class SnippetStore {
 
   getAll(): SavedSnippet[] {
     return this.context.workspaceState.get<SavedSnippet[]>(WORKSPACE_STATE_KEY) ?? [];
+  }
+
+  /**
+   * Returns the stable item keys of every currently pinned snippet.
+   */
+  getPinnedKeys(): string[] {
+    return this.getAll().map(s => getContextItemKey(s.item));
+  }
+
+  findByItemKey(key: string): SavedSnippet | undefined {
+    return this.getAll().find(s => getContextItemKey(s.item) === key);
   }
 
   save(item: ContextItem, name?: string): SavedSnippet {
@@ -27,6 +38,20 @@ export class SnippetStore {
   remove(id: string): void {
     const snippets = this.getAll().filter(s => s.id !== id);
     this.context.workspaceState.update(WORKSPACE_STATE_KEY, snippets);
+  }
+
+  /**
+   * Remove every snippet whose underlying item matches the given key.
+   * Returns true when at least one snippet was removed.
+   */
+  removeByItemKey(key: string): boolean {
+    const snippets = this.getAll();
+    const remaining = snippets.filter(s => getContextItemKey(s.item) !== key);
+    if (remaining.length === snippets.length) {
+      return false;
+    }
+    this.context.workspaceState.update(WORKSPACE_STATE_KEY, remaining);
+    return true;
   }
 
   clear(): void {

--- a/src/test/suite/snippetStore.test.ts
+++ b/src/test/suite/snippetStore.test.ts
@@ -1,0 +1,113 @@
+import { strict as assert } from 'assert';
+import type * as vscode from 'vscode';
+import Module from 'module';
+import { type ContextItem, getContextItemKey } from '../../models/contextItem';
+
+type SnippetStoreCtor = typeof import('../../snippets/snippetStore').SnippetStore;
+type ModuleLoader = typeof Module & {
+  _load: (request: string, parent: object | null | undefined, isMain: boolean) => unknown;
+};
+
+const moduleLoader = Module as unknown as ModuleLoader;
+const originalLoad = moduleLoader._load;
+let SnippetStore: SnippetStoreCtor;
+
+class InMemoryMemento implements vscode.Memento {
+  private readonly store = new Map<string, unknown>();
+
+  keys(): readonly string[] {
+    return [...this.store.keys()];
+  }
+
+  get<T>(key: string): T | undefined;
+  get<T>(key: string, defaultValue: T): T;
+  get<T>(key: string, defaultValue?: T): T | undefined {
+    if (this.store.has(key)) {
+      return this.store.get(key) as T;
+    }
+
+    return defaultValue;
+  }
+
+  async update(key: string, value: unknown): Promise<void> {
+    this.store.set(key, value);
+  }
+}
+
+function createContext(): vscode.ExtensionContext {
+  const workspaceState = new InMemoryMemento();
+
+  return {
+    workspaceState
+  } as unknown as vscode.ExtensionContext;
+}
+
+function createItem(overrides: Partial<ContextItem> = {}): ContextItem {
+  return {
+    source: 'teams',
+    title: 'Daily sync',
+    snippet: 'Pinned excerpt',
+    cache: { hit: false },
+    ...overrides
+  };
+}
+
+suite('SnippetStore', () => {
+  suiteSetup(async () => {
+    moduleLoader._load = (request: string, parent: object | null | undefined, isMain: boolean): unknown => {
+      if (request === 'vscode') {
+        return {};
+      }
+
+      return originalLoad(request, parent, isMain);
+    };
+
+    try {
+      ({ SnippetStore } = await import('../../snippets/snippetStore'));
+    } finally {
+      moduleLoader._load = originalLoad;
+    }
+  });
+
+  test('getPinnedKeys uses fallback identity when url is missing', () => {
+    const store = new SnippetStore(createContext());
+    const first = createItem({ timestamp: '2026-04-18T01:00:00.000Z', snippet: 'alpha' });
+    const second = createItem({ timestamp: '2026-04-18T01:01:00.000Z', snippet: 'beta' });
+
+    store.save(first);
+    store.save(second);
+
+    assert.deepEqual(store.getPinnedKeys(), [
+      getContextItemKey(first),
+      getContextItemKey(second)
+    ]);
+  });
+
+  test('removeByItemKey removes all duplicates for the same item key', () => {
+    const store = new SnippetStore(createContext());
+    const duplicate = createItem({ timestamp: '2026-04-18T01:00:00.000Z', snippet: 'same item' });
+    const different = createItem({ timestamp: '2026-04-18T01:00:01.000Z', snippet: 'different item' });
+
+    store.save(duplicate, 'first copy');
+    store.save(duplicate, 'second copy');
+    store.save(different, 'keep me');
+
+    const removed = store.removeByItemKey(getContextItemKey(duplicate));
+
+    assert.equal(removed, true);
+    assert.equal(store.getAll().length, 1);
+    assert.deepEqual(store.getPinnedKeys(), [getContextItemKey(different)]);
+  });
+
+  test('removeByItemKey returns false when no snippet matches', () => {
+    const store = new SnippetStore(createContext());
+    store.save(createItem({ timestamp: '2026-04-18T01:00:00.000Z' }));
+
+    const removed = store.removeByItemKey(
+      getContextItemKey(createItem({ timestamp: '2026-04-18T01:00:01.000Z' }))
+    );
+
+    assert.equal(removed, false);
+    assert.equal(store.getAll().length, 1);
+  });
+});

--- a/src/webview/chatRenderer.ts
+++ b/src/webview/chatRenderer.ts
@@ -45,11 +45,51 @@ export class ChatRenderer {
   private welcomeEl: HTMLElement | null;
   private vscode: VsCodeApi;
   private loadingElements: Map<string, HTMLElement> = new Map();
+  private pinnedKeys: Set<string> = new Set();
 
   constructor(chatArea: HTMLElement, vscode: VsCodeApi) {
     this.chatArea = chatArea;
     this.welcomeEl = chatArea.querySelector('#welcome');
     this.vscode = vscode;
+  }
+
+  /**
+   * Build the same stable item key the extension host uses.
+   * Must stay in sync with getContextItemKey() in src/models/contextItem.ts.
+   */
+  private getItemKey(item: ContextItem): string {
+    return `${item.source}::${item.url ?? ''}::${item.title}`;
+  }
+
+  /**
+   * Update the set of currently pinned items and refresh every rendered card
+   * so the 📌 indicator and Pin/Unpin button reflect the latest state.
+   */
+  setPinnedItems(keys: string[]): void {
+    this.pinnedKeys = new Set(keys);
+    const cards = this.chatArea.querySelectorAll<HTMLElement>('.result-card[data-item-key]');
+    cards.forEach(card => {
+      const key = card.dataset.itemKey;
+      if (key) {
+        this.applyPinState(card, this.pinnedKeys.has(key));
+      }
+    });
+  }
+
+  private applyPinState(card: HTMLElement, isPinned: boolean): void {
+    card.classList.toggle('pinned', isPinned);
+
+    const indicator = card.querySelector<HTMLElement>('.pin-indicator');
+    if (indicator) {
+      indicator.style.display = isPinned ? '' : 'none';
+    }
+
+    const pinBtn = card.querySelector<HTMLButtonElement>('.action-pin');
+    if (pinBtn) {
+      pinBtn.textContent = isPinned ? 'Unpin' : 'Pin';
+      pinBtn.title = isPinned ? 'Unpin snippet' : 'Pin snippet';
+      pinBtn.setAttribute('aria-pressed', isPinned ? 'true' : 'false');
+    }
   }
 
   /**
@@ -282,6 +322,8 @@ export class ChatRenderer {
     // Store data safely via dataset (auto-escapes)
     if (item.url) { card.dataset.url = item.url; }
     card.dataset.snippet = item.snippet;
+    const itemKey = this.getItemKey(item);
+    card.dataset.itemKey = itemKey;
 
     // Title row
     const titleDiv = document.createElement('div');
@@ -297,6 +339,16 @@ export class ChatRenderer {
     const titleText = document.createElement('span');
     titleText.textContent = item.title;
     titleDiv.appendChild(titleText);
+
+    // Visible 📌 indicator that toggles with the pin state.
+    const pinIndicator = document.createElement('span');
+    pinIndicator.className = 'pin-indicator';
+    pinIndicator.textContent = '📌';
+    pinIndicator.title = 'Pinned snippet';
+    pinIndicator.setAttribute('aria-label', 'Pinned');
+    pinIndicator.style.marginLeft = '4px';
+    pinIndicator.style.display = 'none';
+    titleDiv.appendChild(pinIndicator);
 
     const badge = document.createElement('span');
     badge.className = 'source-badge';
@@ -347,6 +399,7 @@ export class ChatRenderer {
     pinBtn.className = 'action-pin';
     pinBtn.title = 'Pin snippet';
     pinBtn.textContent = 'Pin';
+    pinBtn.setAttribute('aria-pressed', 'false');
     pinBtn.addEventListener('click', () => {
       this.vscode.postMessage({
         command: 'pinSnippet',
@@ -356,6 +409,10 @@ export class ChatRenderer {
     actionsDiv.appendChild(pinBtn);
 
     card.appendChild(actionsDiv);
+
+    // Apply current pin state so a card built after a previous pin shows 📌 immediately.
+    this.applyPinState(card, this.pinnedKeys.has(itemKey));
+
     return card;
   }
 

--- a/src/webview/chatRenderer.ts
+++ b/src/webview/chatRenderer.ts
@@ -58,7 +58,13 @@ export class ChatRenderer {
    * Must stay in sync with getContextItemKey() in src/models/contextItem.ts.
    */
   private getItemKey(item: ContextItem): string {
-    return `${item.source}::${item.url ?? ''}::${item.title}`;
+    const discriminator =
+      item.url?.trim() ||
+      item.timestamp?.trim() ||
+      item.snippet.trim() ||
+      '';
+
+    return `${item.source}::${discriminator}::${item.title}`;
   }
 
   /**

--- a/src/webview/main.ts
+++ b/src/webview/main.ts
@@ -168,5 +168,9 @@ window.addEventListener('message', (event) => {
         message.timestamp as string
       );
       break;
+
+    case 'pinnedItems':
+      renderer.setPinnedItems((message.keys as string[]) ?? []);
+      break;
   }
 });


### PR DESCRIPTION
## Why

Users had no visual confirmation that a search result was pinned, and clicking `Pin` a second time silently saved a duplicate snippet instead of unpinning. This made it easy to lose track of what was already in the pinned context for `/ask`.

## What

The `Pin` button on each result card is now a true toggle:

- First click pins the snippet and shows a 📌 next to the title; the button label switches to `Unpin`.
- Second click removes the snippet and hides the indicator; the button reverts to `Pin`.

## How

- Added a shared `getContextItemKey(item)` helper (`source::url::title`) so the extension host and the webview agree on item identity. The webview re-implements the same key locally to avoid pulling extension code into the bundle.
- `SnippetStore` gained `getPinnedKeys()` and `removeByItemKey()`. `ChatViewProvider.handlePinSnippet` now checks for an existing pin and removes it instead of saving a duplicate.
- A new `pinnedItems` host-to-webview message broadcasts the current pinned key set on `webviewReady`, after every pin/unpin, and on `clearSnippets`. The renderer keeps a `Set` of keys, applies it to newly built cards, and refreshes existing cards on each update so state stays consistent across re-renders.

## Validation

- `npm run compile`
- `npm run lint`
- `npm test` (81 passing)
- `npm run security:check` (0 vulnerabilities)