### PR TITLE
fix(retrieval): use Graph-compliant body for copilot/retrieval (#11)

### DIFF
--- a/src/adapters/retrievalAdapter.ts
+++ b/src/adapters/retrievalAdapter.ts
@@ -8,23 +8,26 @@ import {
   stripSearchMarkup
 } from './retrievalSearchUtils';
 
-interface RetrievalResource {
-  webUrl?: string;
-  name?: string;
-}
-
 interface RetrievalExtract {
   text?: string;
 }
 
+interface RetrievalResourceMetadata {
+  title?: string;
+  name?: string;
+  [key: string]: unknown;
+}
+
 interface RetrievalHit {
-  resource?: RetrievalResource;
+  webUrl?: string;
   extracts?: RetrievalExtract[];
-  relevanceScore?: number;
+  resourceMetadata?: RetrievalResourceMetadata;
+  resourceType?: string;
+  sensitivityLabel?: unknown;
 }
 
 interface RetrievalResponse {
-  value?: RetrievalHit[];
+  retrievalHits?: RetrievalHit[];
 }
 
 interface SearchHitResource {
@@ -162,26 +165,44 @@ async function searchFiles(
 async function searchExternalItems(token: string, query: string): Promise<ContextItem[]> {
   const config = vscode.workspace.getConfiguration('contextRelay');
   const maxResults = config.get<number>('maxResults', 10);
+  // The Copilot retrieval API caps queryString at 1,500 characters and works best with a
+  // single natural-language sentence. Trim excessively long input rather than letting the
+  // service reject the request with HTTP 400.
+  const queryString = query.length > 1500 ? query.slice(0, 1500) : query;
   const url = `${GRAPH_BASE}/v1.0/copilot/retrieval`;
+  // Request body shape per Microsoft Graph retrieval API:
+  //   queryString (top-level string), dataSource, resourceMetadata, maximumNumberOfResults.
+  // The previous shape ({ query: { queryString }, size }) triggered a Graph API 400
+  // "BadRequest" response.
   const body = JSON.stringify({
-    query: { queryString: query },
+    queryString,
     dataSource: 'externalItem',
-    size: maxResults
+    resourceMetadata: ['title'],
+    maximumNumberOfResults: Math.min(Math.max(maxResults, 1), 25)
   });
 
   const response = await graphFetchWithRetry(url, token, { method: 'POST', body });
   const data = await handleGraphResponse(response) as RetrievalResponse;
 
-  return (data?.value ?? []).map(hit => ({
-    source: 'connectors',
-    title: hit.resource?.name ?? 'Untitled',
-    snippet: hit.extracts?.map(e => e.text ?? '').join(' ') ?? '',
-    url: hit.resource?.webUrl,
-    relevance: hit.relevanceScore,
-    cache: { hit: false },
-    raw: {
-      extracts: hit.extracts?.map(e => e.text ?? '').filter(Boolean) ?? []
-    }
-  }));
+  return (data?.retrievalHits ?? []).map(hit => {
+    const extracts = hit.extracts?.map(e => e.text ?? '').filter(Boolean) ?? [];
+    const title =
+      (typeof hit.resourceMetadata?.title === 'string' && hit.resourceMetadata.title) ||
+      (typeof hit.resourceMetadata?.name === 'string' && hit.resourceMetadata.name) ||
+      getTitleFromUrl(hit.webUrl ?? '') ||
+      'Untitled';
+
+    return {
+      source: 'connectors',
+      title,
+      snippet: extracts.join(' '),
+      url: hit.webUrl,
+      cache: { hit: false },
+      raw: {
+        extracts,
+        resourceType: hit.resourceType
+      }
+    };
+  });
 }
 

--- a/src/test/suite/retrievalAdapter.test.ts
+++ b/src/test/suite/retrievalAdapter.test.ts
@@ -1,7 +1,39 @@
 import { strict as assert } from 'assert';
+import Module from 'module';
 import { buildSearchSnippet, escapeODataString, isOneDriveUrl, stripSearchMarkup } from '../../adapters/retrievalSearchUtils';
 
+type SearchRetrievalFn = typeof import('../../adapters/retrievalAdapter').searchRetrieval;
+type ModuleLoader = typeof Module & {
+  _load: (request: string, parent: object | null | undefined, isMain: boolean) => unknown;
+};
+
+const moduleLoader = Module as unknown as ModuleLoader;
+const originalLoad = moduleLoader._load;
+let searchRetrieval: SearchRetrievalFn;
+
 suite('Retrieval adapter', () => {
+  suiteSetup(async () => {
+    moduleLoader._load = (request: string, parent: object | null | undefined, isMain: boolean): unknown => {
+      if (request === 'vscode') {
+        return {
+          workspace: {
+            getConfiguration: () => ({
+              get: <T>(_key: string, defaultValue: T): T => defaultValue
+            })
+          }
+        };
+      }
+
+      return originalLoad(request, parent, isMain);
+    };
+
+    try {
+      ({ searchRetrieval } = await import('../../adapters/retrievalAdapter'));
+    } finally {
+      moduleLoader._load = originalLoad;
+    }
+  });
+
   test('escapes single quotes for OData search', () => {
     assert.equal(escapeODataString("O'Brien plan"), "O''Brien plan");
   });
@@ -26,5 +58,77 @@ suite('Retrieval adapter', () => {
       buildSearchSnippet('<c0>Architecture</c0> review <ddd/> excerpt', undefined, 'https://contoso-my.sharepoint.com/personal/user/Documents/file.docx'),
       'Architecture review … excerpt'
     );
+  });
+
+  test('externalItem retrieval sends Graph-compliant request body and parses retrievalHits', async () => {
+    const originalFetch = globalThis.fetch;
+    let capturedUrl: string | undefined;
+    let capturedInit: RequestInit | undefined;
+
+    globalThis.fetch = (async (input: Parameters<typeof fetch>[0], init?: RequestInit): Promise<Response> => {
+      capturedUrl = typeof input === 'string' ? input : input.toString();
+      capturedInit = init;
+      const responseBody = {
+        retrievalHits: [
+          {
+            webUrl: 'https://example.com/doc/1',
+            extracts: [{ text: 'First extract' }, { text: 'Second extract' }],
+            resourceMetadata: { title: 'Connector Document' },
+            resourceType: 'externalItem'
+          }
+        ]
+      };
+      return new Response(JSON.stringify(responseBody), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' }
+      });
+    }) as typeof fetch;
+
+    try {
+      const items = await searchRetrieval('token', 'translate this mail please', 'externalItem');
+
+      assert.equal(capturedUrl, 'https://graph.microsoft.com/v1.0/copilot/retrieval');
+      assert.equal(capturedInit?.method, 'POST');
+
+      const body = JSON.parse(capturedInit?.body as string);
+      assert.equal(body.queryString, 'translate this mail please');
+      assert.equal(body.dataSource, 'externalItem');
+      assert.equal(typeof body.maximumNumberOfResults, 'number');
+      assert.ok(body.maximumNumberOfResults >= 1 && body.maximumNumberOfResults <= 25);
+      // The earlier, buggy shape wrapped the query and used `size`, which Graph rejects with HTTP 400.
+      assert.equal(body.query, undefined, 'queryString must be top-level, not nested under "query"');
+      assert.equal(body.size, undefined, 'must use maximumNumberOfResults, not "size"');
+
+      assert.equal(items.length, 1);
+      assert.equal(items[0].source, 'connectors');
+      assert.equal(items[0].title, 'Connector Document');
+      assert.equal(items[0].url, 'https://example.com/doc/1');
+      assert.equal(items[0].snippet, 'First extract Second extract');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test('externalItem retrieval truncates queryString at 1500 chars to avoid Graph 400', async () => {
+    const originalFetch = globalThis.fetch;
+    let capturedInit: RequestInit | undefined;
+
+    globalThis.fetch = (async (_input: Parameters<typeof fetch>[0], init?: RequestInit): Promise<Response> => {
+      capturedInit = init;
+      return new Response(JSON.stringify({ retrievalHits: [] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' }
+      });
+    }) as typeof fetch;
+
+    try {
+      const longQuery = 'a'.repeat(2000);
+      await searchRetrieval('token', longQuery, 'externalItem');
+
+      const body = JSON.parse(capturedInit?.body as string);
+      assert.equal(body.queryString.length, 1500);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   });
 });


### PR DESCRIPTION
## Why

Pinning an email and entering an unprefixed prompt like "このメールを翻訳してください" surfaced `🔗 Connectors: Graph API error 400: BadRequest` whenever `contextRelay.adapters.connectors` was enabled. Unprefixed prompts fan out to every adapter via `handleSearch`, so the malformed connectors request broke the whole response.

Fixes #11.

## What changed

`searchExternalItems` in `src/adapters/retrievalAdapter.ts` was sending a non-spec body (`{ query: { queryString }, size }`) and parsing a non-spec response (`data.value` / `hit.resource.webUrl`) to `POST /v1.0/copilot/retrieval`. The Graph Copilot retrieval API expects top-level `queryString` plus `maximumNumberOfResults` and returns `retrievalHits[]` with flat `webUrl` and `resourceMetadata`.

- Rebuilt the request body to match the spec: `queryString` (top-level, truncated to the 1500-char service limit), `dataSource: 'externalItem'`, `resourceMetadata: ['title']`, `maximumNumberOfResults` clamped to 1..25.
- Rewrote the response types and mapping to read `retrievalHits`, `hit.webUrl`, and `hit.resourceMetadata.title`, falling back to `getTitleFromUrl` when the title metadata is absent.
- Added regression tests in `src/test/suite/retrievalAdapter.test.ts` that stub `globalThis.fetch`, assert the outgoing URL and body shape (no `query`, no `size`, `maximumNumberOfResults` in range), verify `ContextItem` parsing from `retrievalHits`, and cover the 1500-char truncation.

## Notes for reviewers

- The adapter is the single call site for both `panelProvider.handleSearch` and `chatViewProvider`, so both paths are fixed by this change.
- Test compilation runs without DOM lib, so the fetch stub uses `Parameters<typeof fetch>[0]` instead of `RequestInfo`.
- Validation: `npm run lint`, `npm run compile`, `npm test` (86/86), `npm run security:check` (0 vulns) all pass.