### PR TITLE
fix(chatAdapter): use /chat endpoint and documented body shape for Copilot Chat API

### DIFF
--- a/src/adapters/chatAdapter.ts
+++ b/src/adapters/chatAdapter.ts
@@ -14,9 +14,29 @@ interface CreateConversationResponse {
   id?: string;
 }
 
-interface MessageResponse {
-  value?: { content?: string }[];
-  content?: string;
+interface CopilotChatResponseMessage {
+  '@odata.type'?: string;
+  id?: string;
+  text?: string;
+  createdDateTime?: string;
+}
+
+interface ChatResponse {
+  messages?: CopilotChatResponseMessage[];
+}
+
+/**
+ * Resolve the IANA time zone for the `locationHint` parameter required by the
+ * Microsoft 365 Copilot Chat API. Falls back to `UTC` when the runtime does not
+ * provide a resolvable time zone.
+ */
+function resolveTimeZone(): string {
+  try {
+    const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    return tz && tz.length > 0 ? tz : 'UTC';
+  } catch {
+    return 'UTC';
+  }
 }
 
 export async function createConversation(token: string): Promise<string> {
@@ -37,16 +57,30 @@ export async function sendMessage(
   conversationId: string,
   message: string
 ): Promise<string> {
-  const url = `${GRAPH_BASE}/beta/copilot/conversations/${conversationId}/messages`;
-  const body = JSON.stringify({ content: message });
+  // Microsoft 365 Copilot Chat API (preview):
+  // POST /beta/copilot/conversations/{conversationId}/chat
+  // See: https://learn.microsoft.com/microsoft-365/copilot/extensibility/api/ai-services/chat/copilotconversation-chat
+  const url = `${GRAPH_BASE}/beta/copilot/conversations/${conversationId}/chat`;
+  const body = JSON.stringify({
+    message: { text: message },
+    locationHint: { timeZone: resolveTimeZone() }
+  });
 
   const response = await graphFetchWithRetry(url, token, { method: 'POST', body });
-  const data = await handleGraphResponse(response) as MessageResponse;
+  const data = await handleGraphResponse(response) as ChatResponse;
 
-  const content = (data as { content?: string })?.content
-    ?? data?.value?.[0]?.content
-    ?? '';
-  return content;
+  // Response contains the full conversation turn: the echoed user message
+  // followed by the assistant reply. Pick the last message that has non-empty
+  // text and is not the prompt we just sent.
+  const messages = Array.isArray(data?.messages) ? data.messages : [];
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const text = messages[i]?.text;
+    if (typeof text === 'string' && text.trim().length > 0 && text !== message) {
+      return text;
+    }
+  }
+
+  return '';
 }
 
 /**

--- a/src/test/suite/chatAdapter.test.ts
+++ b/src/test/suite/chatAdapter.test.ts
@@ -1,0 +1,139 @@
+import { strict as assert } from 'assert';
+import { createConversation, sendMessage } from '../../adapters/chatAdapter';
+
+interface CapturedRequest {
+  url: string;
+  init: RequestInit;
+}
+
+function installFetchStub(
+  responder: (req: CapturedRequest) => { status: number; body: unknown }
+): { restore: () => void; captured: CapturedRequest[] } {
+  const captured: CapturedRequest[] = [];
+  const originalFetch = globalThis.fetch;
+
+  globalThis.fetch = (async (input: unknown, init?: RequestInit): Promise<Response> => {
+    const url = typeof input === 'string' ? input : String(input);
+    const req: CapturedRequest = { url, init: init ?? {} };
+    captured.push(req);
+    const { status, body } = responder(req);
+    const text = typeof body === 'string' ? body : JSON.stringify(body);
+    return new Response(text, {
+      status,
+      headers: { 'Content-Type': 'application/json' }
+    });
+  }) as typeof globalThis.fetch;
+
+  return {
+    restore: () => {
+      globalThis.fetch = originalFetch;
+    },
+    captured
+  };
+}
+
+suite('Chat adapter', () => {
+  test('createConversation POSTs empty body to /beta/copilot/conversations and returns id', async () => {
+    const stub = installFetchStub(() => ({
+      status: 201,
+      body: { id: 'conv-123', state: 'active', turnCount: 0 }
+    }));
+    try {
+      const id = await createConversation('token-abc');
+      assert.equal(id, 'conv-123');
+      assert.equal(stub.captured.length, 1);
+      const req = stub.captured[0];
+      assert.equal(req.url, 'https://graph.microsoft.com/beta/copilot/conversations');
+      assert.equal(req.init.method, 'POST');
+      assert.equal(req.init.body, '{}');
+      const headers = req.init.headers as Record<string, string>;
+      assert.equal(headers.Authorization, 'Bearer token-abc');
+      assert.equal(headers['Content-Type'], 'application/json');
+    } finally {
+      stub.restore();
+    }
+  });
+
+  test('sendMessage POSTs /chat endpoint with documented body and returns assistant reply text', async () => {
+    const stub = installFetchStub(() => ({
+      status: 200,
+      body: {
+        id: 'conv-123',
+        state: 'active',
+        turnCount: 1,
+        messages: [
+          {
+            '@odata.type': '#microsoft.graph.copilotConversationResponseMessage',
+            id: 'echo-1',
+            text: 'hello copilot'
+          },
+          {
+            '@odata.type': '#microsoft.graph.copilotConversationResponseMessage',
+            id: 'reply-1',
+            text: 'Hello! How can I help?'
+          }
+        ]
+      }
+    }));
+    try {
+      const reply = await sendMessage('token-abc', 'conv-123', 'hello copilot');
+      assert.equal(reply, 'Hello! How can I help?');
+      assert.equal(stub.captured.length, 1);
+      const req = stub.captured[0];
+      assert.equal(req.url, 'https://graph.microsoft.com/beta/copilot/conversations/conv-123/chat');
+      assert.equal(req.init.method, 'POST');
+      const body = JSON.parse(String(req.init.body));
+      assert.deepEqual(body.message, { text: 'hello copilot' });
+      assert.ok(body.locationHint && typeof body.locationHint.timeZone === 'string' && body.locationHint.timeZone.length > 0,
+        'locationHint.timeZone must be a non-empty string');
+    } finally {
+      stub.restore();
+    }
+  });
+
+  test('sendMessage skips echoed prompt when selecting assistant reply', async () => {
+    const stub = installFetchStub(() => ({
+      status: 200,
+      body: {
+        messages: [
+          { text: 'prompt text' },
+          { text: 'assistant answer' }
+        ]
+      }
+    }));
+    try {
+      const reply = await sendMessage('t', 'c', 'prompt text');
+      assert.equal(reply, 'assistant answer');
+    } finally {
+      stub.restore();
+    }
+  });
+
+  test('sendMessage returns empty string when no assistant reply present', async () => {
+    const stub = installFetchStub(() => ({
+      status: 200,
+      body: { messages: [] }
+    }));
+    try {
+      const reply = await sendMessage('t', 'c', 'q');
+      assert.equal(reply, '');
+    } finally {
+      stub.restore();
+    }
+  });
+
+  test('sendMessage surfaces Graph error text on non-2xx response', async () => {
+    const stub = installFetchStub(() => ({
+      status: 404,
+      body: { error: { code: 'UnknownError', message: '' } }
+    }));
+    try {
+      await assert.rejects(
+        () => sendMessage('t', 'c', 'q'),
+        (err: Error) => /Graph API error 404/.test(err.message)
+      );
+    } finally {
+      stub.restore();
+    }
+  });
+});


### PR DESCRIPTION
Fixes #13

## Problem

`/ask` with a pinned mail surfaced `Graph API error 404: {"error":{"code":"UnknownError",...}}` from the webview. `src/adapters/chatAdapter.ts` sent requests to `POST /beta/copilot/conversations/{id}/messages` with `{ content: message }`, but the Microsoft 365 Copilot Chat API (preview) does not expose a `/messages` sub-resource.

## Fix

Per [Microsoft Learn — copilotConversation: chat](https://learn.microsoft.com/microsoft-365/copilot/extensibility/api/ai-services/chat/copilotconversation-chat):

- `sendMessage()` now POSTs to `POST /beta/copilot/conversations/{conversationId}/chat`.
- Request body matches the documented shape:
  ```json
  {
    "message": { "text": "<prompt>" },
    "locationHint": { "timeZone": "<IANA tz>" }
  }
  ```
  `locationHint.timeZone` is required; we derive it from `Intl.DateTimeFormat().resolvedOptions().timeZone` with `UTC` fallback.
- Response parsing walks `data.messages[]` from the end and returns the last non-empty `text` that is not the echoed prompt.
- `createConversation()` behavior is unchanged (`POST /beta/copilot/conversations` with `{}` body) but its response typing was kept minimal.

## Tests

New `src/test/suite/chatAdapter.test.ts`:
- `createConversation` issues correct URL/headers/body and returns `id`.
- `sendMessage` POSTs the `/chat` endpoint with the documented body and a non-empty `locationHint.timeZone`.
- Assistant reply selection skips the echoed user prompt.
- Empty `messages[]` returns `''`.
- Non-2xx response surfaces `Graph API error 404`.

## Validation

- `npm run compile` ✅
- `npm run lint` ✅
- `npm test` ✅ (93 tests pass, includes 5 new)
- `npm run security:check` ✅ 0 vulnerabilities
