### PR TITLE
feat: add /clear slash command to clear chat and pinned snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ ContextRelay is a VS Code extension that surfaces relevant Microsoft 365 context
 | `/sharepoint <query>` | SharePoint sites & pages |
 | `/onedrive <query>` | OneDrive files |
 | `/all <query>` | All enabled sources (same as no prefix) |
+| `/ask <instruction>` | Send pinned snippets to Microsoft 365 Copilot and open the reply in a new editor |
+| `/clear` | Clear the chat transcript and discard all pinned snippets |
 
 - **Snippet pinning** -- Save any search result as a named snippet, visible across sessions.
 - **Timestamped handoff docs** -- Generate Markdown documents that capture current context.

--- a/src/panel/chatViewProvider.ts
+++ b/src/panel/chatViewProvider.ts
@@ -238,6 +238,11 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
       return;
     }
 
+    if (parsed.target === 'clear') {
+      this.handleClearCommand();
+      return;
+    }
+
     const targetSources = this.getTargetSources(parsed.target);
     if (targetSources.length === 0) {
       const message = 'No ContextRelay adapters are enabled.';
@@ -332,6 +337,23 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
     }
   }
 
+  private handleClearCommand(): void {
+    const hadSnippets = this.snippetStore.getAll().length > 0;
+    this.snippetStore.clear();
+    this.latestSearchSummary = undefined;
+    this.postMessage({ command: 'clearChat' });
+    this.sendPinnedItems();
+    const text = hadSnippets
+      ? 'Chat cleared. All pinned snippets discarded.'
+      : 'Chat cleared.';
+    this.postMessage({
+      command: 'assistantMessage',
+      kind: 'info',
+      text,
+      timestamp: new Date().toISOString()
+    });
+  }
+
   private async handleAskCommand(prompt: string): Promise<void> {
     const snippets = this.snippetStore.getAll();
     if (snippets.length === 0) {
@@ -398,6 +420,10 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
         sources.push('connectors');
       }
       return target === 'all' ? sources : [];
+    }
+
+    if (target === 'clear') {
+      return [];
     }
 
     return [target];

--- a/src/panel/types.ts
+++ b/src/panel/types.ts
@@ -26,6 +26,7 @@ export const SLASH_COMMANDS: SlashCommand[] = [
   { command: '/onedrive', label: '/onedrive', description: 'Search OneDrive', icon: '☁️', source: 'onedrive' },
   { command: '/all', label: '/all', description: 'Search all sources', icon: '🔍', source: 'all' },
   { command: '/ask', label: '/ask', description: 'Ask Microsoft 365 Copilot using pinned snippets as context', icon: '🤖' },
+  { command: '/clear', label: '/clear', description: 'Clear chat and discard pinned snippets', icon: '🧹' },
 ];
 
 // --- Messages: Webview → Extension host ---

--- a/src/router/commandRouter.ts
+++ b/src/router/commandRouter.ts
@@ -1,4 +1,4 @@
-export type RouteTarget = 'mail' | 'teams' | 'sharepoint' | 'onedrive' | 'all' | 'ask';
+export type RouteTarget = 'mail' | 'teams' | 'sharepoint' | 'onedrive' | 'all' | 'ask' | 'clear';
 
 export interface ParsedCommand {
   target: RouteTarget;
@@ -12,7 +12,8 @@ const SLASH_COMMANDS: Record<string, RouteTarget> = {
   sharepoint: 'sharepoint',
   onedrive: 'onedrive',
   all: 'all',
-  ask: 'ask'
+  ask: 'ask',
+  clear: 'clear'
 };
 
 function normalizeQuery(input: string): string {
@@ -32,7 +33,9 @@ export function parseCommand(input: string): ParsedCommand {
     const query = target === 'ask' ? rawQuery.trim() : normalizeQuery(rawQuery);
 
     if (target) {
-      return { target, query, isEmpty: query.length === 0 };
+      // /clear takes no arguments and is never treated as empty so it always executes.
+      const isEmpty = target === 'clear' ? false : query.length === 0;
+      return { target, query, isEmpty };
     }
     // Unknown slash command — treat as /all with the original input
     return { target: 'all', query: normalized, isEmpty: normalized.length === 0 };
@@ -48,7 +51,8 @@ export function getHelpText(command: string): string {
     sharepoint: 'Example: /sharepoint VPN setup guide\nExample: /sharepoint architecture',
     onedrive: 'Example: /onedrive architecture diagram\nExample: /onedrive Q3 report',
     all: 'Example: /all architecture decisions\nOr just type a query without a slash command.',
-    ask: 'Example: /ask 日本語に翻訳してmarkdownにして\nExample: /ask Summarize the pinned docs as a bullet list\nPinned snippets are used as context and the Microsoft 365 Copilot response is opened in a new editor tab.'
+    ask: 'Example: /ask 日本語に翻訳してmarkdownにして\nExample: /ask Summarize the pinned docs as a bullet list\nPinned snippets are used as context and the Microsoft 365 Copilot response is opened in a new editor tab.',
+    clear: 'Example: /clear\nClears the current chat transcript and discards all pinned snippets.'
   };
   return examples[command] ?? 'Type a query to search Microsoft 365 content.';
 }

--- a/src/router/commandRouter.ts
+++ b/src/router/commandRouter.ts
@@ -30,7 +30,11 @@ export function parseCommand(input: string): ParsedCommand {
     const rawQuery = commandMatch?.[2] ?? '';
     // For /ask, preserve newlines in the user's instruction so the prompt keeps its original shape.
     const target = SLASH_COMMANDS[command];
-    const query = target === 'ask' ? rawQuery.trim() : normalizeQuery(rawQuery);
+    const query = target === 'ask'
+      ? rawQuery.trim()
+      : target === 'clear'
+        ? ''
+        : normalizeQuery(rawQuery);
 
     if (target) {
       // /clear takes no arguments and is never treated as empty so it always executes.

--- a/src/test/suite/commandRouter.test.ts
+++ b/src/test/suite/commandRouter.test.ts
@@ -123,6 +123,7 @@ suite('CommandRouter', () => {
   test('/clear ignores trailing arguments but still executes', () => {
     const result = parseCommand('/clear everything now');
     assert.equal(result.target, 'clear');
+    assert.equal(result.query, '');
     assert.equal(result.isEmpty, false);
   });
 

--- a/src/test/suite/commandRouter.test.ts
+++ b/src/test/suite/commandRouter.test.ts
@@ -112,4 +112,23 @@ suite('CommandRouter', () => {
     const text = getHelpText('ask');
     assert.ok(text.toLowerCase().includes('microsoft 365 copilot'));
   });
+
+  test('/clear command routes to clear with empty query but is not isEmpty', () => {
+    const result = parseCommand('/clear');
+    assert.equal(result.target, 'clear');
+    assert.equal(result.query, '');
+    assert.equal(result.isEmpty, false);
+  });
+
+  test('/clear ignores trailing arguments but still executes', () => {
+    const result = parseCommand('/clear everything now');
+    assert.equal(result.target, 'clear');
+    assert.equal(result.isEmpty, false);
+  });
+
+  test('getHelpText for clear describes the effect', () => {
+    const text = getHelpText('clear');
+    assert.ok(text.toLowerCase().includes('clear'));
+    assert.ok(text.toLowerCase().includes('pinned'));
+  });
 });

--- a/src/webview/slashMenu.ts
+++ b/src/webview/slashMenu.ts
@@ -17,6 +17,7 @@ const SLASH_ITEMS: SlashMenuItem[] = [
   { command: '/onedrive', label: '/onedrive', description: 'Search OneDrive', icon: '☁️' },
   { command: '/all', label: '/all', description: 'Search all sources', icon: '🔍' },
   { command: '/ask', label: '/ask', description: 'Ask Microsoft 365 Copilot using pinned snippets', icon: '🤖' },
+  { command: '/clear', label: '/clear', description: 'Clear chat and discard pinned snippets', icon: '🧹' },
 ];
 
 export class SlashMenu {


### PR DESCRIPTION
## Summary

Adds a new `/clear` slash command that:

- Clears the chat transcript in the webview.
- Discards **all pinned snippets** from the snippet store.
- Resets the cached search summary.
- Posts a short confirmation message in the chat.

## Changes

- `src/router/commandRouter.ts` — added `clear` to `RouteTarget`, registered `/clear` in `SLASH_COMMANDS`, special-cased `isEmpty` so `/clear` (no args) still executes, and added help text.
- `src/panel/chatViewProvider.ts` — dispatches `/clear` in `handleQuery` and implements `handleClearCommand()`; `getTargetSources` returns `[]` for `clear`.
- `src/panel/types.ts` + `src/webview/slashMenu.ts` — added `/clear` to the slash-command menu (icon 🧹).
- `src/test/suite/commandRouter.test.ts` — added three tests covering `parseCommand('/clear')`, `/clear` with trailing args, and `getHelpText('clear')`.
- `README.md` — documented `/clear` (and `/ask`) in the command table.

## Validation

All AGENTS.md gates pass:

- `npm run compile` ✅
- `npm run lint` ✅
- `npm test` ✅ (96 tests passing)
- `npm run security:check` ✅ (0 vulnerabilities)

Fixes #15