### PR TITLE
feat: Add ellipsis menu to webview panel

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,22 @@
         "command": "contextRelay.moveToPrimarySideBar",
         "title": "ContextRelay: Move to Primary Side Bar",
         "icon": "$(layout-sidebar-left)"
+      },
+      {
+        "command": "contextRelay.moveChatToEditorArea",
+        "title": "Move Chat into Editor Area"
+      },
+      {
+        "command": "contextRelay.moveChatToNewWindow",
+        "title": "Move Chat into New Window"
+      },
+      {
+        "command": "contextRelay.showDebugLog",
+        "title": "Show Debug Log"
+      },
+      {
+        "command": "contextRelay.openSettings",
+        "title": "Chat Settings"
       }
     ],
     "menus": {
@@ -93,6 +109,26 @@
           "command": "contextRelay.moveToPrimarySideBar",
           "when": "view == contextRelay.chatView && contextRelay.viewLocation == 'secondarySideBar'",
           "group": "navigation@100"
+        },
+        {
+          "command": "contextRelay.moveChatToEditorArea",
+          "when": "view == contextRelay.chatView",
+          "group": "1_move@1"
+        },
+        {
+          "command": "contextRelay.moveChatToNewWindow",
+          "when": "view == contextRelay.chatView",
+          "group": "1_move@2"
+        },
+        {
+          "command": "contextRelay.showDebugLog",
+          "when": "view == contextRelay.chatView",
+          "group": "2_debug@1"
+        },
+        {
+          "command": "contextRelay.openSettings",
+          "when": "view == contextRelay.chatView",
+          "group": "3_settings@1"
         }
       ]
     },

--- a/package.json
+++ b/package.json
@@ -83,19 +83,23 @@
       },
       {
         "command": "contextRelay.moveChatToEditorArea",
-        "title": "Move Chat into Editor Area"
+        "title": "ContextRelay: Move Chat into Editor Area",
+        "shortTitle": "Move Chat into Editor Area"
       },
       {
         "command": "contextRelay.moveChatToNewWindow",
-        "title": "Move Chat into New Window"
+        "title": "ContextRelay: Move Chat into New Window",
+        "shortTitle": "Move Chat into New Window"
       },
       {
         "command": "contextRelay.showDebugLog",
-        "title": "Show Debug Log"
+        "title": "ContextRelay: Show Debug Log",
+        "shortTitle": "Show Debug Log"
       },
       {
         "command": "contextRelay.openSettings",
-        "title": "Chat Settings"
+        "title": "ContextRelay: Chat Settings",
+        "shortTitle": "Chat Settings"
       }
     ],
     "menus": {

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
         },
         {
           "command": "contextRelay.moveToPrimarySideBar",
-          "when": "view == contextRelay.chatView && contextRelay.viewLocation == 'secondarySideBar'",
+          "when": "view == contextRelay.chatView && contextRelay.viewLocation != 'primarySideBar'",
           "group": "navigation@100"
         },
         {
@@ -178,6 +178,11 @@
           "type": "boolean",
           "default": true,
           "description": "Enable the Chat tab (Copilot Chat API is in beta)"
+        },
+        "contextRelay.enableGraphDebugLogging": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enable Graph API debug logging in the ContextRelay Debug output channel"
         },
         "contextRelay.adapters.mail": {
           "type": "boolean",

--- a/src/adapters/graphClient.ts
+++ b/src/adapters/graphClient.ts
@@ -2,11 +2,30 @@ import { ContextItem, ContextSource } from '../models/contextItem';
 
 const GRAPH_BASE = 'https://graph.microsoft.com';
 
+/**
+ * Logger interface for Graph API debug logging.
+ * Implementations should write to a VS Code OutputChannel.
+ */
+export interface GraphLogger {
+  log(message: string): void;
+}
+
+let _logger: GraphLogger | undefined;
+
+/**
+ * Set the global Graph API logger. Call once during extension activation.
+ */
+export function setGraphLogger(logger: GraphLogger): void {
+  _logger = logger;
+}
+
 export async function graphFetch(
   url: string,
   token: string,
   options: RequestInit = {}
 ): Promise<Response> {
+  _logger?.log(`→ ${options.method ?? 'GET'} ${url}`);
+
   const response = await fetch(url, {
     ...options,
     headers: {
@@ -15,6 +34,9 @@ export async function graphFetch(
       ...(options.headers as Record<string, string> ?? {})
     }
   });
+
+  _logger?.log(`← ${response.status} ${response.statusText} ${url}`);
+
   return response;
 }
 
@@ -37,6 +59,7 @@ export async function graphFetchWithRetry(
         : delay;
 
       if (attempt < maxRetries) {
+        _logger?.log(`⚠ Throttled (${response.status}), retry ${attempt + 1}/${maxRetries} after ${retryDelay}ms`);
         await sleep(Math.min(retryDelay, 30000));
         delay = Math.min(delay * 2, 30000);
         continue;
@@ -65,6 +88,8 @@ export async function handleGraphResponse(response: Response): Promise<unknown> 
   } catch {
     // ignore
   }
+
+  _logger?.log(`✖ Graph API error ${status}: ${body.slice(0, 500)}`);
 
   if (status === 401) {
     throw Object.assign(new Error('Unauthorized: session expired, please re-authenticate.'), { code: 401 });

--- a/src/adapters/graphClient.ts
+++ b/src/adapters/graphClient.ts
@@ -15,7 +15,7 @@ let _logger: GraphLogger | undefined;
 /**
  * Set the global Graph API logger. Call once during extension activation.
  */
-export function setGraphLogger(logger: GraphLogger): void {
+export function setGraphLogger(logger: GraphLogger | undefined): void {
   _logger = logger;
 }
 
@@ -89,7 +89,7 @@ export async function handleGraphResponse(response: Response): Promise<unknown> 
     // ignore
   }
 
-  _logger?.log(`✖ Graph API error ${status}: ${body.slice(0, 500)}`);
+  _logger?.log(buildGraphErrorLog(status, body, response));
 
   if (status === 401) {
     throw Object.assign(new Error('Unauthorized: session expired, please re-authenticate.'), { code: 401 });
@@ -108,6 +108,35 @@ export async function handleGraphResponse(response: Response): Promise<unknown> 
   }
 
   throw new Error(`Graph API error ${status}: ${body}`);
+}
+
+function buildGraphErrorLog(status: number, body: string, response: Response): string {
+  const errorCode = getGraphErrorCode(body);
+  const requestId = response.headers.get('request-id') ?? response.headers.get('client-request-id');
+  const parts = [`✖ Graph API error ${status}`];
+
+  if (errorCode) {
+    parts.push(`code=${errorCode}`);
+  }
+
+  if (requestId) {
+    parts.push(`requestId=${requestId}`);
+  }
+
+  return parts.join(' ');
+}
+
+function getGraphErrorCode(body: string): string | undefined {
+  if (!body) {
+    return undefined;
+  }
+
+  try {
+    const parsed = JSON.parse(body) as { error?: { code?: string } };
+    return parsed.error?.code;
+  } catch {
+    return undefined;
+  }
 }
 
 export { GRAPH_BASE, ContextItem, ContextSource };

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,11 +5,47 @@ import { ChatViewProvider } from './panel/chatViewProvider';
 import { AuthProvider } from './auth/authProvider';
 import { setGraphLogger } from './adapters/graphClient';
 
+type ViewLocation = 'primarySideBar' | 'secondarySideBar' | 'editorArea';
+
 export function activate(context: vscode.ExtensionContext): void {
-  // Create debug output channel for Graph API logging
-  const debugChannel = vscode.window.createOutputChannel('ContextRelay Debug');
-  context.subscriptions.push(debugChannel);
-  setGraphLogger({ log: (msg: string) => debugChannel.appendLine(`[${new Date().toISOString()}] ${msg}`) });
+  const GRAPH_DEBUG_LOGGING_CONFIG_KEY = 'enableGraphDebugLogging';
+  let debugChannel: vscode.OutputChannel | undefined;
+
+  const ensureDebugChannel = (): vscode.OutputChannel => {
+    if (!debugChannel) {
+      debugChannel = vscode.window.createOutputChannel('ContextRelay Debug');
+      context.subscriptions.push(debugChannel);
+    }
+
+    return debugChannel;
+  };
+
+  const enableGraphDebugLogging = (): vscode.OutputChannel => {
+    const channel = ensureDebugChannel();
+    setGraphLogger({
+      log: (msg: string) => channel.appendLine(`[${new Date().toISOString()}] ${msg}`)
+    });
+    return channel;
+  };
+
+  const syncGraphDebugLogging = (): void => {
+    const isEnabled = vscode.workspace
+      .getConfiguration('contextRelay')
+      .get<boolean>(GRAPH_DEBUG_LOGGING_CONFIG_KEY, false);
+
+    setGraphLogger(isEnabled ? {
+      log: (msg: string) => ensureDebugChannel().appendLine(`[${new Date().toISOString()}] ${msg}`)
+    } : undefined);
+  };
+
+  syncGraphDebugLogging();
+  context.subscriptions.push(
+    vscode.workspace.onDidChangeConfiguration((event) => {
+      if (event.affectsConfiguration(`contextRelay.${GRAPH_DEBUG_LOGGING_CONFIG_KEY}`)) {
+        syncGraphDebugLogging();
+      }
+    })
+  );
 
   const authProvider = new AuthProvider(context);
   const chatViewProvider = new ChatViewProvider(context, authProvider, context.extensionUri);
@@ -21,10 +57,10 @@ export function activate(context: vscode.ExtensionContext): void {
   // Restore the last-known location from globalState so the toggle is correct
   // across VS Code sessions (not always reset to primarySideBar on activation).
   const VIEW_LOCATION_KEY = 'contextRelay.viewLocation';
-  const savedLocation = context.globalState.get<string>(VIEW_LOCATION_KEY, 'primarySideBar');
+  const savedLocation = context.globalState.get<ViewLocation>(VIEW_LOCATION_KEY, 'primarySideBar');
   void vscode.commands.executeCommand('setContext', VIEW_LOCATION_KEY, savedLocation);
 
-  const setViewLocation = async (location: string): Promise<void> => {
+  const setViewLocation = async (location: ViewLocation): Promise<void> => {
     await context.globalState.update(VIEW_LOCATION_KEY, location);
     await vscode.commands.executeCommand('setContext', VIEW_LOCATION_KEY, location);
   };
@@ -60,6 +96,15 @@ export function activate(context: vscode.ExtensionContext): void {
       await vscode.commands.executeCommand('workbench.action.moveFocusedView');
       await setViewLocation('primarySideBar');
     }
+  };
+
+  const moveToEditorArea = async (): Promise<void> => {
+    await vscode.commands.executeCommand('vscode.moveViews', {
+      viewIds: [ChatViewProvider.viewType],
+      destinationId: '_.editor.newcontainer'
+    });
+    await setViewLocation('editorArea');
+    await focusPanel();
   };
 
   const generateHandoffDocs = async (): Promise<string[]> => {
@@ -206,12 +251,12 @@ export function activate(context: vscode.ExtensionContext): void {
   context.subscriptions.push(
     vscode.commands.registerCommand('contextRelay.moveChatToEditorArea', async () => {
       try {
-        await vscode.commands.executeCommand(`${ChatViewProvider.viewType}.focus`);
-        await vscode.commands.executeCommand('workbench.action.moveEditorToFirstGroup');
+        await moveToEditorArea();
       } catch {
         // Fallback: let the user pick the destination via the built-in quick pick
         await vscode.commands.executeCommand(`${ChatViewProvider.viewType}.focus`);
         await vscode.commands.executeCommand('workbench.action.moveFocusedView');
+        await setViewLocation('editorArea');
       }
     })
   );
@@ -219,19 +264,26 @@ export function activate(context: vscode.ExtensionContext): void {
   context.subscriptions.push(
     vscode.commands.registerCommand('contextRelay.moveChatToNewWindow', async () => {
       try {
-        await vscode.commands.executeCommand(`${ChatViewProvider.viewType}.focus`);
+        await moveToEditorArea();
+        await focusPanel();
         await vscode.commands.executeCommand('workbench.action.moveEditorToNewWindow');
       } catch {
-        // Fallback: let the user pick the destination via the built-in quick pick
-        await vscode.commands.executeCommand(`${ChatViewProvider.viewType}.focus`);
-        await vscode.commands.executeCommand('workbench.action.moveFocusedView');
+        try {
+          await focusPanel();
+          await vscode.commands.executeCommand('workbench.action.moveFocusedView');
+        } catch {
+          // Ignore fallback errors and surface a clear message below.
+        }
+        vscode.window.showWarningMessage(
+          'ContextRelay: Could not move chat directly into a new window. Move it into the editor area first, then move the active editor to a new window.'
+        );
       }
     })
   );
 
   context.subscriptions.push(
     vscode.commands.registerCommand('contextRelay.showDebugLog', () => {
-      debugChannel.show(true);
+      enableGraphDebugLogging().show(true);
     })
   );
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,8 +3,14 @@ import * as vscode from 'vscode';
 import * as fs from 'fs';
 import { ChatViewProvider } from './panel/chatViewProvider';
 import { AuthProvider } from './auth/authProvider';
+import { setGraphLogger } from './adapters/graphClient';
 
 export function activate(context: vscode.ExtensionContext): void {
+  // Create debug output channel for Graph API logging
+  const debugChannel = vscode.window.createOutputChannel('ContextRelay Debug');
+  context.subscriptions.push(debugChannel);
+  setGraphLogger({ log: (msg: string) => debugChannel.appendLine(`[${new Date().toISOString()}] ${msg}`) });
+
   const authProvider = new AuthProvider(context);
   const chatViewProvider = new ChatViewProvider(context, authProvider, context.extensionUri);
   const focusPanel = async (): Promise<void> => {
@@ -193,6 +199,54 @@ export function activate(context: vscode.ExtensionContext): void {
 
   context.subscriptions.push(
     vscode.commands.registerCommand('contextRelay.moveToPrimarySideBar', moveToPrimarySideBar)
+  );
+
+  // --- Ellipsis menu commands ---
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand('contextRelay.moveChatToEditorArea', async () => {
+      try {
+        await vscode.commands.executeCommand('vscode.moveViews', {
+          viewIds: [ChatViewProvider.viewType],
+          destinationId: 'workbench.editor.chatSessionEditor'
+        });
+      } catch {
+        // Fallback for older VS Code versions: use the generic move command
+        await vscode.commands.executeCommand(`${ChatViewProvider.viewType}.focus`);
+        await vscode.commands.executeCommand('workbench.action.moveFocusedView');
+      }
+    })
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand('contextRelay.moveChatToNewWindow', async () => {
+      try {
+        // Move view to editor area first, then to a new window
+        await vscode.commands.executeCommand('vscode.moveViews', {
+          viewIds: [ChatViewProvider.viewType],
+          destinationId: 'workbench.editor.chatSessionEditor'
+        });
+        // Small delay to allow the view to settle in the editor area
+        await new Promise<void>(resolve => setTimeout(resolve, 300));
+        await vscode.commands.executeCommand('workbench.action.moveEditorToNewWindow');
+      } catch {
+        // Fallback: focus the view and let the user pick
+        await vscode.commands.executeCommand(`${ChatViewProvider.viewType}.focus`);
+        await vscode.commands.executeCommand('workbench.action.moveFocusedView');
+      }
+    })
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand('contextRelay.showDebugLog', () => {
+      debugChannel.show(true);
+    })
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand('contextRelay.openSettings', async () => {
+      await vscode.commands.executeCommand('workbench.action.openSettings', 'contextRelay');
+    })
   );
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -206,12 +206,10 @@ export function activate(context: vscode.ExtensionContext): void {
   context.subscriptions.push(
     vscode.commands.registerCommand('contextRelay.moveChatToEditorArea', async () => {
       try {
-        await vscode.commands.executeCommand('vscode.moveViews', {
-          viewIds: [ChatViewProvider.viewType],
-          destinationId: 'workbench.editor.chatSessionEditor'
-        });
+        await vscode.commands.executeCommand(`${ChatViewProvider.viewType}.focus`);
+        await vscode.commands.executeCommand('workbench.action.moveEditorToFirstGroup');
       } catch {
-        // Fallback for older VS Code versions: use the generic move command
+        // Fallback: let the user pick the destination via the built-in quick pick
         await vscode.commands.executeCommand(`${ChatViewProvider.viewType}.focus`);
         await vscode.commands.executeCommand('workbench.action.moveFocusedView');
       }
@@ -221,16 +219,10 @@ export function activate(context: vscode.ExtensionContext): void {
   context.subscriptions.push(
     vscode.commands.registerCommand('contextRelay.moveChatToNewWindow', async () => {
       try {
-        // Move view to editor area first, then to a new window
-        await vscode.commands.executeCommand('vscode.moveViews', {
-          viewIds: [ChatViewProvider.viewType],
-          destinationId: 'workbench.editor.chatSessionEditor'
-        });
-        // Small delay to allow the view to settle in the editor area
-        await new Promise<void>(resolve => setTimeout(resolve, 300));
+        await vscode.commands.executeCommand(`${ChatViewProvider.viewType}.focus`);
         await vscode.commands.executeCommand('workbench.action.moveEditorToNewWindow');
       } catch {
-        // Fallback: focus the view and let the user pick
+        // Fallback: let the user pick the destination via the built-in quick pick
         await vscode.commands.executeCommand(`${ChatViewProvider.viewType}.focus`);
         await vscode.commands.executeCommand('workbench.action.moveFocusedView');
       }

--- a/src/test/suite/ellipsisMenu.test.ts
+++ b/src/test/suite/ellipsisMenu.test.ts
@@ -29,10 +29,10 @@ suite('Ellipsis menu manifest entries', () => {
   const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8')) as PackageJson;
 
   const ellipsisCommands = [
-    { id: 'contextRelay.moveChatToEditorArea', title: 'Move Chat into Editor Area', group: '1_move' },
-    { id: 'contextRelay.moveChatToNewWindow', title: 'Move Chat into New Window', group: '1_move' },
-    { id: 'contextRelay.showDebugLog', title: 'Show Debug Log', group: '2_debug' },
-    { id: 'contextRelay.openSettings', title: 'Chat Settings', group: '3_settings' },
+    { id: 'contextRelay.moveChatToEditorArea', title: 'ContextRelay: Move Chat into Editor Area', group: '1_move' },
+    { id: 'contextRelay.moveChatToNewWindow', title: 'ContextRelay: Move Chat into New Window', group: '1_move' },
+    { id: 'contextRelay.showDebugLog', title: 'ContextRelay: Show Debug Log', group: '2_debug' },
+    { id: 'contextRelay.openSettings', title: 'ContextRelay: Chat Settings', group: '3_settings' },
   ];
 
   for (const cmd of ellipsisCommands) {

--- a/src/test/suite/ellipsisMenu.test.ts
+++ b/src/test/suite/ellipsisMenu.test.ts
@@ -1,7 +1,7 @@
 import { strict as assert } from 'assert';
 import * as fs from 'fs';
 import * as path from 'path';
-import { setGraphLogger, GraphLogger } from '../../adapters/graphClient';
+import { graphFetch, handleGraphResponse, setGraphLogger, GraphLogger } from '../../adapters/graphClient';
 
 interface PackageCommand {
   command: string;
@@ -20,6 +20,12 @@ interface PackageJson {
     commands?: PackageCommand[];
     menus?: {
       'view/title'?: ViewTitleMenuItem[];
+    };
+    configuration?: {
+      properties?: Record<string, {
+        type?: string;
+        default?: unknown;
+      }>;
     };
   };
 }
@@ -69,19 +75,78 @@ suite('Ellipsis menu manifest entries', () => {
       );
     }
   });
+
+  test('declares opt-in graph debug logging configuration', () => {
+    const setting = packageJson.contributes?.configuration?.properties?.['contextRelay.enableGraphDebugLogging'];
+    assert.ok(setting, 'contextRelay.enableGraphDebugLogging must be declared');
+    assert.equal(setting?.type, 'boolean');
+    assert.equal(setting?.default, false);
+  });
 });
 
 suite('Graph API debug logger', () => {
-  test('setGraphLogger accepts a logger implementation', () => {
+  test('setGraphLogger accepts a logger implementation without emitting logs', () => {
     const messages: string[] = [];
     const logger: GraphLogger = { log: (msg: string) => messages.push(msg) };
-    // Should not throw
-    setGraphLogger(logger);
-    assert.ok(true, 'setGraphLogger accepted a logger without error');
+
+    assert.doesNotThrow(() => setGraphLogger(logger));
+    assert.deepEqual(messages, []);
+    setGraphLogger(undefined);
   });
 
   test('GraphLogger interface has log method', () => {
     const logger: GraphLogger = { log: () => {} };
     assert.equal(typeof logger.log, 'function');
+  });
+
+  test('graphFetch logs request and response details', async () => {
+    const messages: string[] = [];
+    const originalFetch = globalThis.fetch;
+
+    setGraphLogger({ log: (msg: string) => messages.push(msg) });
+    globalThis.fetch = (async () => new Response('{}', {
+      status: 200,
+      statusText: 'OK',
+      headers: { 'Content-Type': 'application/json' }
+    })) as typeof globalThis.fetch;
+
+    try {
+      await graphFetch('https://graph.microsoft.com/v1.0/me', 'token-abc', { method: 'POST' });
+      assert.deepEqual(messages, [
+        '→ POST https://graph.microsoft.com/v1.0/me',
+        '← 200 OK https://graph.microsoft.com/v1.0/me'
+      ]);
+    } finally {
+      globalThis.fetch = originalFetch;
+      setGraphLogger(undefined);
+    }
+  });
+
+  test('handleGraphResponse logs redacted error details', async () => {
+    const messages: string[] = [];
+    setGraphLogger({ log: (msg: string) => messages.push(msg) });
+
+    const response = new Response(JSON.stringify({
+      error: {
+        code: 'Forbidden',
+        message: 'secret body content'
+      }
+    }), {
+      status: 403,
+      headers: {
+        'Content-Type': 'application/json',
+        'request-id': 'req-123'
+      }
+    });
+
+    try {
+      await assert.rejects(() => handleGraphResponse(response), /Forbidden \(403\)/);
+      assert.deepEqual(messages, [
+        '✖ Graph API error 403 code=Forbidden requestId=req-123'
+      ]);
+      assert.ok(!messages[0].includes('secret body content'));
+    } finally {
+      setGraphLogger(undefined);
+    }
   });
 });

--- a/src/test/suite/ellipsisMenu.test.ts
+++ b/src/test/suite/ellipsisMenu.test.ts
@@ -1,0 +1,87 @@
+import { strict as assert } from 'assert';
+import * as fs from 'fs';
+import * as path from 'path';
+import { setGraphLogger, GraphLogger } from '../../adapters/graphClient';
+
+interface PackageCommand {
+  command: string;
+  title: string;
+  icon?: string;
+}
+
+interface ViewTitleMenuItem {
+  command: string;
+  when?: string;
+  group?: string;
+}
+
+interface PackageJson {
+  contributes?: {
+    commands?: PackageCommand[];
+    menus?: {
+      'view/title'?: ViewTitleMenuItem[];
+    };
+  };
+}
+
+suite('Ellipsis menu manifest entries', () => {
+  const packageJsonPath = path.resolve(__dirname, '../../../../package.json');
+  const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8')) as PackageJson;
+
+  const ellipsisCommands = [
+    { id: 'contextRelay.moveChatToEditorArea', title: 'Move Chat into Editor Area', group: '1_move' },
+    { id: 'contextRelay.moveChatToNewWindow', title: 'Move Chat into New Window', group: '1_move' },
+    { id: 'contextRelay.showDebugLog', title: 'Show Debug Log', group: '2_debug' },
+    { id: 'contextRelay.openSettings', title: 'Chat Settings', group: '3_settings' },
+  ];
+
+  for (const cmd of ellipsisCommands) {
+    test(`contributes "${cmd.id}" command`, () => {
+      const commands = packageJson.contributes?.commands ?? [];
+      const found = commands.find(c => c.command === cmd.id);
+      assert.ok(found, `${cmd.id} must be contributed in package.json`);
+      assert.equal(found?.title, cmd.title);
+    });
+
+    test(`registers "${cmd.id}" in view/title menu under ${cmd.group} group`, () => {
+      const viewTitleMenu = packageJson.contributes?.menus?.['view/title'] ?? [];
+      const entry = viewTitleMenu.find(m => m.command === cmd.id);
+      assert.ok(entry, `view/title must include ${cmd.id}`);
+      assert.ok(
+        entry?.when?.includes('contextRelay.chatView'),
+        `${cmd.id} menu entry must be scoped to contextRelay.chatView`
+      );
+      assert.ok(
+        entry?.group?.startsWith(cmd.group),
+        `${cmd.id} must appear in the ${cmd.group} group, got "${entry?.group}"`
+      );
+    });
+  }
+
+  test('ellipsis menu commands do not appear in navigation group', () => {
+    const viewTitleMenu = packageJson.contributes?.menus?.['view/title'] ?? [];
+    for (const cmd of ellipsisCommands) {
+      const entry = viewTitleMenu.find(m => m.command === cmd.id);
+      assert.ok(entry, `view/title must include ${cmd.id}`);
+      assert.ok(
+        !entry?.group?.startsWith('navigation'),
+        `${cmd.id} must NOT be in the navigation group (would show as icon, not in ellipsis menu)`
+      );
+    }
+  });
+});
+
+suite('Graph API debug logger', () => {
+  test('setGraphLogger accepts a logger implementation', () => {
+    const messages: string[] = [];
+    const logger: GraphLogger = { log: (msg: string) => messages.push(msg) };
+    // Should not throw
+    setGraphLogger(logger);
+    assert.ok(true, 'setGraphLogger accepted a logger without error');
+  });
+
+  test('GraphLogger interface has log method', () => {
+    const logger: GraphLogger = { log: () => {} };
+    assert.equal(typeof logger.log, 'function');
+  });
+});


### PR DESCRIPTION
## Summary
Add a VS Code-style three-dot (⋯) overflow menu to the ContextRelay chat view title bar.

## Included menu items
| Menu item | Description |
| --- | --- |
| **Move Chat into Editor Area** | Moves the chat view into the editor area using `vscode.moveViews` with the editor container destination. |
| **Move Chat into New Window** | Moves the chat view into the editor area, focuses it, and then moves the active editor to a new window. |
| **Show Debug Log** | Opens the `ContextRelay Debug` output channel and enables opt-in Graph API debug logging for the session. |
| **Chat Settings** | Opens the VS Code settings UI filtered to `contextRelay`. |

## Technical details
- Added new `view/title` menu contributions under `1_move`, `2_debug`, and `3_settings` so the commands appear in the overflow menu instead of the navigation icon group.
- Preserved the existing sidebar navigation icons and added `editorArea` view-location tracking so those sidebar actions remain correct after moving the view out of the sidebar.
- Added opt-in Graph API debug logging through `GraphLogger`, gated by `contextRelay.enableGraphDebugLogging` or explicit use of **Show Debug Log**.
- Redacted debug error logging to avoid writing raw Graph response bodies to the output channel.
- Strengthened test coverage for manifest contributions, the debug-logging configuration, and logger behavior.

## Validation
- `npm run compile`
- `npm run lint`
- `npm test`
- `npm run security:check`

## Issues
Closes #17
Closes #18
Closes #19
Closes #20
Closes #21