### PR TITLE
fix: use extension-managed context key for panel move buttons

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,12 +114,12 @@
       "view/title": [
         {
           "command": "contextRelay.moveToSecondarySideBar",
-          "when": "view == contextRelay.chatView && viewContainerLocation != 'auxiliarybar'",
+          "when": "view == contextRelay.chatView && contextRelay.viewLocation != 'auxiliarybar'",
           "group": "navigation@100"
         },
         {
           "command": "contextRelay.moveToPrimarySideBar",
-          "when": "view == contextRelay.chatView && viewContainerLocation != 'sidebar'",
+          "when": "view == contextRelay.chatView && contextRelay.viewLocation != 'sidebar'",
           "group": "navigation@100"
         },
         {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,8 +2,10 @@ import './suppressPunycodeDeprecation.install';
 import * as vscode from 'vscode';
 import * as fs from 'fs';
 import { ChatViewProvider } from './panel/chatViewProvider';
+import { VIEW_LOCATION_CONTEXT_KEY } from './panel/chatViewConstants';
 import {
   ChatMoveRuntime,
+  ViewLocation,
   moveChatToPrimarySideBar,
   moveChatToSecondarySideBar,
   openChatInEditorArea,
@@ -12,7 +14,7 @@ import {
 import { AuthProvider } from './auth/authProvider';
 import { setGraphLogger } from './adapters/graphClient';
 
-export function activate(context: vscode.ExtensionContext): void {
+export async function activate(context: vscode.ExtensionContext): Promise<void> {
   const GRAPH_DEBUG_LOGGING_CONFIG_KEY = 'enableGraphDebugLogging';
   let debugChannel: vscode.OutputChannel | undefined;
 
@@ -57,9 +59,19 @@ export function activate(context: vscode.ExtensionContext): void {
   const focusPanel = async (): Promise<void> => {
     await vscode.commands.executeCommand(`${ChatViewProvider.viewType}.focus`);
   };
+
+  // Set the initial view location context key so only one move button is visible
+  await vscode.commands.executeCommand('setContext', VIEW_LOCATION_CONTEXT_KEY, 'sidebar');
+
   const moveRuntime: ChatMoveRuntime = {
     executeCommand: (command: string, ...args: unknown[]) => vscode.commands.executeCommand(command, ...args),
     focusView: focusPanel,
+    focusAuxiliaryBar: async () => {
+      await vscode.commands.executeCommand('workbench.action.focusAuxiliaryBar');
+    },
+    setViewLocation: async (location: ViewLocation) => {
+      await vscode.commands.executeCommand('setContext', VIEW_LOCATION_CONTEXT_KEY, location);
+    },
     openInEditorArea: () => chatViewProvider.openInEditorArea()
   };
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,6 +11,7 @@ import {
   openChatInEditorArea,
   openChatInNewWindow
 } from './panel/chatMoveCommands';
+import { persistViewLocation, readStoredViewLocation } from './panel/viewLocationState';
 import { AuthProvider } from './auth/authProvider';
 import { setGraphLogger } from './adapters/graphClient';
 
@@ -61,7 +62,11 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   };
 
   // Set the initial view location context key so only one move button is visible
-  await vscode.commands.executeCommand('setContext', VIEW_LOCATION_CONTEXT_KEY, 'sidebar');
+  await vscode.commands.executeCommand(
+    'setContext',
+    VIEW_LOCATION_CONTEXT_KEY,
+    readStoredViewLocation(context)
+  );
 
   const moveRuntime: ChatMoveRuntime = {
     executeCommand: (command: string, ...args: unknown[]) => vscode.commands.executeCommand(command, ...args),
@@ -70,6 +75,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       await vscode.commands.executeCommand('workbench.action.focusAuxiliaryBar');
     },
     setViewLocation: async (location: ViewLocation) => {
+      await persistViewLocation(context, location);
       await vscode.commands.executeCommand('setContext', VIEW_LOCATION_CONTEXT_KEY, location);
     },
     openInEditorArea: () => chatViewProvider.openInEditorArea()

--- a/src/panel/chatMoveCommands.ts
+++ b/src/panel/chatMoveCommands.ts
@@ -4,9 +4,13 @@ import {
   SECONDARY_SIDEBAR_CONTAINER_ID
 } from './chatViewConstants';
 
+export type ViewLocation = 'sidebar' | 'auxiliarybar';
+
 export interface ChatMoveRuntime {
   executeCommand(command: string, ...args: unknown[]): Thenable<unknown>;
   focusView(): Promise<void>;
+  focusAuxiliaryBar(): Promise<void>;
+  setViewLocation(location: ViewLocation): Promise<void>;
   openInEditorArea(): Promise<void>;
 }
 
@@ -15,6 +19,7 @@ export async function moveChatToPrimarySideBar(runtime: ChatMoveRuntime): Promis
     viewIds: [CHAT_VIEW_ID],
     destinationId: PRIMARY_SIDEBAR_CONTAINER_ID
   });
+  await runtime.setViewLocation('sidebar');
   await runtime.focusView();
 }
 
@@ -23,6 +28,8 @@ export async function moveChatToSecondarySideBar(runtime: ChatMoveRuntime): Prom
     viewIds: [CHAT_VIEW_ID],
     destinationId: SECONDARY_SIDEBAR_CONTAINER_ID
   });
+  await runtime.setViewLocation('auxiliarybar');
+  await runtime.focusAuxiliaryBar();
   await runtime.focusView();
 }
 

--- a/src/panel/chatViewConstants.ts
+++ b/src/panel/chatViewConstants.ts
@@ -2,3 +2,4 @@ export const CHAT_VIEW_ID = 'contextRelay.chatView';
 export const CHAT_EDITOR_PANEL_ID = 'contextRelay.chatPanel';
 export const PRIMARY_SIDEBAR_CONTAINER_ID = 'workbench.view.extension.contextRelay';
 export const SECONDARY_SIDEBAR_CONTAINER_ID = 'workbench.view.extension.contextRelaySecondary';
+export const VIEW_LOCATION_CONTEXT_KEY = 'contextRelay.viewLocation';

--- a/src/panel/viewLocationState.ts
+++ b/src/panel/viewLocationState.ts
@@ -1,0 +1,18 @@
+import type * as vscode from 'vscode';
+import type { ViewLocation } from './chatMoveCommands';
+import { VIEW_LOCATION_CONTEXT_KEY } from './chatViewConstants';
+
+export function readStoredViewLocation(
+  context: Pick<vscode.ExtensionContext, 'globalState'>
+): ViewLocation {
+  const stored = context.globalState.get<unknown>(VIEW_LOCATION_CONTEXT_KEY);
+
+  return stored === 'auxiliarybar' || stored === 'sidebar' ? stored : 'sidebar';
+}
+
+export async function persistViewLocation(
+  context: Pick<vscode.ExtensionContext, 'globalState'>,
+  location: ViewLocation
+): Promise<void> {
+  await context.globalState.update(VIEW_LOCATION_CONTEXT_KEY, location);
+}

--- a/src/test/suite/chatMoveCommands.test.ts
+++ b/src/test/suite/chatMoveCommands.test.ts
@@ -1,6 +1,7 @@
 import { strict as assert } from 'assert';
 import {
   ChatMoveRuntime,
+  ViewLocation,
   moveChatToPrimarySideBar,
   moveChatToSecondarySideBar,
   openChatInEditorArea,
@@ -17,6 +18,8 @@ suite('Chat move commands', () => {
     const calls: Array<{ command: string; args: unknown[] }> = [];
     let editorOpens = 0;
     let focusCalls = 0;
+    let auxBarFocusCalls = 0;
+    const locationHistory: ViewLocation[] = [];
 
     const runtime: ChatMoveRuntime = {
       executeCommand: async (command: string, ...args: unknown[]) => {
@@ -24,6 +27,12 @@ suite('Chat move commands', () => {
       },
       focusView: async () => {
         focusCalls += 1;
+      },
+      focusAuxiliaryBar: async () => {
+        auxBarFocusCalls += 1;
+      },
+      setViewLocation: async (location: ViewLocation) => {
+        locationHistory.push(location);
       },
       openInEditorArea: async () => {
         editorOpens += 1;
@@ -33,11 +42,15 @@ suite('Chat move commands', () => {
     return {
       runtime,
       calls,
+      locationHistory,
       get editorOpens() {
         return editorOpens;
       },
       get focusCalls() {
         return focusCalls;
+      },
+      get auxBarFocusCalls() {
+        return auxBarFocusCalls;
       }
     };
   };
@@ -56,6 +69,7 @@ suite('Chat move commands', () => {
         }]
       }
     ]);
+    assert.deepEqual(harness.locationHistory, ['sidebar']);
     assert.equal(harness.focusCalls, 1);
   });
 
@@ -73,6 +87,8 @@ suite('Chat move commands', () => {
         }]
       }
     ]);
+    assert.deepEqual(harness.locationHistory, ['auxiliarybar']);
+    assert.equal(harness.auxBarFocusCalls, 1, 'must focus the auxiliary bar after moving');
     assert.equal(harness.focusCalls, 1);
     assert.ok(
       !SECONDARY_SIDEBAR_CONTAINER_ID.startsWith('_.'),

--- a/src/test/suite/manifestConsistency.test.ts
+++ b/src/test/suite/manifestConsistency.test.ts
@@ -100,8 +100,8 @@ suite('Extension manifest consistency', () => {
       'moveToSecondarySideBar menu entry must be scoped to the chatView'
     );
     assert.ok(
-      moveRightEntry?.when?.includes("viewContainerLocation != 'auxiliarybar'"),
-      'moveToSecondarySideBar must key off the built-in viewContainerLocation context'
+      moveRightEntry?.when?.includes("contextRelay.viewLocation != 'auxiliarybar'"),
+      'moveToSecondarySideBar must use the extension-managed contextRelay.viewLocation context key'
     );
     assert.ok(
       moveRightEntry?.group?.startsWith('navigation'),
@@ -114,17 +114,17 @@ suite('Extension manifest consistency', () => {
       'moveToPrimarySideBar menu entry must be scoped to the chatView'
     );
     assert.ok(
-      moveLeftEntry?.when?.includes("viewContainerLocation != 'sidebar'"),
-      'moveToPrimarySideBar must key off the built-in viewContainerLocation context'
+      moveLeftEntry?.when?.includes("contextRelay.viewLocation != 'sidebar'"),
+      'moveToPrimarySideBar must use the extension-managed contextRelay.viewLocation context key'
     );
     assert.ok(
       moveLeftEntry?.group?.startsWith('navigation'),
       'moveToPrimarySideBar must appear in the navigation group'
     );
     assert.ok(
-      !moveRightEntry?.when?.includes('contextRelay.viewLocation') &&
-      !moveLeftEntry?.when?.includes('contextRelay.viewLocation'),
-      'sidebar move menu entries must not depend on the stale custom location context key'
+      !moveRightEntry?.when?.includes('viewContainerLocation') &&
+      !moveLeftEntry?.when?.includes('viewContainerLocation'),
+      'sidebar move menu entries must not depend on the unreliable built-in viewContainerLocation context key'
     );
   });
 });

--- a/src/test/suite/viewLocationState.test.ts
+++ b/src/test/suite/viewLocationState.test.ts
@@ -1,0 +1,57 @@
+import { strict as assert } from 'assert';
+import type * as vscode from 'vscode';
+import { persistViewLocation, readStoredViewLocation } from '../../panel/viewLocationState';
+
+class InMemoryMemento implements vscode.Memento {
+  private readonly store = new Map<string, unknown>();
+
+  keys(): readonly string[] {
+    return [...this.store.keys()];
+  }
+
+  get<T>(key: string): T | undefined;
+  get<T>(key: string, defaultValue: T): T;
+  get<T>(key: string, defaultValue?: T): T | undefined {
+    if (this.store.has(key)) {
+      return this.store.get(key) as T;
+    }
+
+    return defaultValue;
+  }
+
+  async update(key: string, value: unknown): Promise<void> {
+    this.store.set(key, value);
+  }
+
+  setKeysForSync(_keys: readonly string[]): void {}
+}
+
+function createContext(): Pick<vscode.ExtensionContext, 'globalState'> {
+  return {
+    globalState: new InMemoryMemento()
+  };
+}
+
+suite('View location state', () => {
+  test('defaults to the primary sidebar when no stored location exists', () => {
+    const context = createContext();
+
+    assert.equal(readStoredViewLocation(context), 'sidebar');
+  });
+
+  test('defaults to the primary sidebar when stored data is invalid', async () => {
+    const context = createContext();
+
+    await context.globalState.update('contextRelay.viewLocation', 'editor');
+
+    assert.equal(readStoredViewLocation(context), 'sidebar');
+  });
+
+  test('reads the last persisted auxiliary bar location', async () => {
+    const context = createContext();
+
+    await persistViewLocation(context, 'auxiliarybar');
+
+    assert.equal(readStoredViewLocation(context), 'auxiliarybar');
+  });
+});


### PR DESCRIPTION
## Why

PR #26 replaced the custom `contextRelay.viewLocation` context key with the built-in `viewContainerLocation` when-clause context. However:

1. **Both sidebar-move buttons appeared simultaneously** — `viewContainerLocation` is not reliably evaluated in all VS Code versions/scopes, so both `!= 'auxiliarybar'` and `!= 'sidebar'` conditions evaluate to `true`.
2. **Neither button moved the panel** — the auxiliary bar was not focused after `vscode.moveViews`, so even a successful move was invisible to the user.

## What changed

- **Custom context key**: Switch back to `contextRelay.viewLocation`, set via `setContext` on activation (`'sidebar'`) and updated after every move
- **Auxiliary bar focus**: After moving to the secondary sidebar, explicitly call `workbench.action.focusAuxiliaryBar` to ensure the target panel is visible
- **Updated `ChatMoveRuntime`**: Added `setViewLocation()` and `focusAuxiliaryBar()` methods
- **Updated manifest**: `when` clauses now use `contextRelay.viewLocation` instead of `viewContainerLocation`
- **Updated tests**: Verify context key updates and auxiliary bar focus

## Validation

- `npm run compile` ✅
- `npm run lint` ✅
- `npm test` ✅ (114 passing)
- `npm run security:check` ✅ (0 vulnerabilities)

Closes #27