### PR TITLE
Fix secondary sidebar manifest key

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
           "icon": "media/icon.svg"
         }
       ],
-      "auxiliarybar": [
+      "secondarySidebar": [
         {
           "id": "contextRelaySecondary",
           "title": "ContextRelay",

--- a/src/test/suite/manifestConsistency.test.ts
+++ b/src/test/suite/manifestConsistency.test.ts
@@ -21,6 +21,7 @@ interface PackageJson {
     commands?: PackageCommand[];
     viewsContainers?: {
       activitybar?: Array<{ id: string; title: string; icon?: string }>;
+      secondarySidebar?: Array<{ id: string; title: string; icon?: string }>;
       auxiliarybar?: Array<{ id: string; title: string; icon?: string }>;
     };
     menus?: {
@@ -49,13 +50,18 @@ suite('Extension manifest consistency', () => {
     assert.ok(container?.icon?.endsWith('.svg'), 'Activity bar icon must point to an SVG asset');
   });
 
-  test('declares a dedicated auxiliary bar container for sidebar moves', () => {
-    const auxiliarybar = packageJson.contributes?.viewsContainers?.auxiliarybar ?? [];
-    const container = auxiliarybar.find(view => view.id === 'contextRelaySecondary');
+  test('declares a dedicated secondary sidebar container for sidebar moves', () => {
+    const secondarySidebar = packageJson.contributes?.viewsContainers?.secondarySidebar ?? [];
+    const container = secondarySidebar.find(view => view.id === 'contextRelaySecondary');
 
-    assert.ok(container, 'ContextRelay auxiliary bar container must exist');
+    assert.ok(container, 'ContextRelay secondary sidebar container must exist');
     assert.equal(container?.title, 'ContextRelay');
-    assert.ok(container?.icon?.endsWith('.svg'), 'Auxiliary bar icon must point to an SVG asset');
+    assert.ok(container?.icon?.endsWith('.svg'), 'Secondary sidebar icon must point to an SVG asset');
+    assert.equal(
+      packageJson.contributes?.viewsContainers?.auxiliarybar,
+      undefined,
+      'ContextRelay must not use the obsolete viewsContainers.auxiliarybar manifest key'
+    );
   });
 
   test('compile script produces the declared runtime entrypoint', () => {


### PR DESCRIPTION
## Why
Clicking ContextRelay's "Move to Secondary Side Bar" button opened the Copilot panel instead of the ContextRelay view. The secondary sidebar container was being contributed under the obsolete `viewsContainers.auxiliarybar` manifest key, so VS Code never registered the destination container even though the generated `workbench.view.extension.contextRelaySecondary` ID was correct.

## What changed
- switch the manifest contribution from `viewsContainers.auxiliarybar` to `viewsContainers.secondarySidebar`
- keep the existing runtime destination ID unchanged, since it already matches VS Code's extension container ID format
- update the manifest regression test to assert the supported `secondarySidebar` contribution and fail if `auxiliarybar` is reintroduced

## Validation
- `npm run compile`
- `npm run lint`
- `npm test`
- `npm run security:check`

Closes #29