### PR TITLE
Fix OneNote Graph hierarchy field selection

### DIFF
--- a/src/adapters/onenoteAdapter.ts
+++ b/src/adapters/onenoteAdapter.ts
@@ -5,7 +5,7 @@ import { parseQueryIntent, scoreMatches } from './queryIntent';
 
 interface OneNotePageParent {
   id?: string;
-  name?: string;
+  displayName?: string;
 }
 
 interface OneNotePageLinks {
@@ -62,7 +62,7 @@ export async function searchOneNote(token: string, query: string): Promise<Conte
 }
 
 async function listRecentPages(token: string, scanLimit: number): Promise<OneNotePage[]> {
-  const url = `${GRAPH_BASE}/v1.0/me/onenote/pages?$top=${scanLimit}&$select=id,title,createdDateTime,lastModifiedDateTime,contentUrl,links&$expand=parentSection($select=id,name),parentNotebook($select=id,name)`;
+  const url = `${GRAPH_BASE}/v1.0/me/onenote/pages?$top=${scanLimit}&$select=id,title,createdDateTime,lastModifiedDateTime,contentUrl,links&$expand=parentSection($select=id,displayName),parentNotebook($select=id,displayName)`;
   const response = await graphFetchWithRetry(url, token, { method: 'GET' });
   const data = await handleGraphResponse(response) as OneNotePageResponse;
   return data.value?.filter(page => page.id) ?? [];
@@ -96,7 +96,7 @@ function computePageScore(
   const titleScore = scoreMatches(page.title ?? '', searchTerms) * 4;
   const previewScore = scoreMatches(previewText, searchTerms) * 3;
   const hierarchyScore = includeHierarchy
-    ? (scoreMatches(page.parentSection?.name ?? '', searchTerms) + scoreMatches(page.parentNotebook?.name ?? '', searchTerms)) * 2
+    ? (scoreMatches(page.parentSection?.displayName ?? '', searchTerms) + scoreMatches(page.parentNotebook?.displayName ?? '', searchTerms)) * 2
     : 0;
 
   return titleScore + previewScore + hierarchyScore;
@@ -115,8 +115,8 @@ function compareCandidates(left: PageCandidate, right: PageCandidate): number {
 
 function mapCandidate(candidate: PageCandidate, includeHierarchy: boolean): ContextItem {
   const { page, previewText } = candidate;
-  const sectionName = page.parentSection?.name?.trim();
-  const notebookName = page.parentNotebook?.name?.trim();
+  const sectionName = page.parentSection?.displayName?.trim();
+  const notebookName = page.parentNotebook?.displayName?.trim();
   const hierarchy = [sectionName, notebookName].filter(Boolean).join(' · ');
   const body = previewText || 'No preview text is available for this page yet.';
 

--- a/src/test/suite/onenoteAdapter.test.ts
+++ b/src/test/suite/onenoteAdapter.test.ts
@@ -39,6 +39,8 @@ suite('OneNote adapter', () => {
     globalThis.fetch = (async (input: Parameters<typeof fetch>[0]): Promise<Response> => {
       const url = typeof input === 'string' ? input : input.toString();
       if (url.includes('/v1.0/me/onenote/pages?')) {
+        assert.ok(url.includes('parentSection($select=id,displayName)'));
+        assert.ok(url.includes('parentNotebook($select=id,displayName)'));
         return jsonResponse({
           value: [
             {
@@ -47,16 +49,16 @@ suite('OneNote adapter', () => {
               lastModifiedDateTime: '2026-04-01T00:00:00Z',
               contentUrl: 'https://graph.microsoft.com/v1.0/me/onenote/pages/page-1/content',
               links: { oneNoteWebUrl: { href: 'https://example.com/onenote/page-1' } },
-              parentSection: { name: 'Architecture' },
-              parentNotebook: { name: 'Engineering wiki' }
+              parentSection: { displayName: 'Architecture' },
+              parentNotebook: { displayName: 'Engineering wiki' }
             },
             {
               id: 'page-2',
               title: 'Random page',
               lastModifiedDateTime: '2026-03-01T00:00:00Z',
               links: { oneNoteWebUrl: { href: 'https://example.com/onenote/page-2' } },
-              parentSection: { name: 'General' },
-              parentNotebook: { name: 'Misc' }
+              parentSection: { displayName: 'General' },
+              parentNotebook: { displayName: 'Misc' }
             }
           ]
         });


### PR DESCRIPTION
## Why

Follow-up to #31.

OneNote searches could fail at runtime with a Graph API 400 error before any preview or body matching ran. The page listing request expanded `parentSection` and `parentNotebook` with `name`, but the OneNote Graph resources expose `displayName`.

## What changed

- switch the OneNote page query to request `displayName` for `parentSection` and `parentNotebook`
- update hierarchy scoring and mapping to read `displayName` instead of `name`
- update the OneNote adapter test to match the real Graph payload shape and assert the corrected OData query

## Validation

- `npm run compile`
- `npm run lint`
- `npm test`
- `npm run security:check`