### PR TITLE
Add Microsoft To Do support to /task search

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ ContextRelay is a VS Code extension that surfaces relevant Microsoft 365 context
 | `/sharepoint <query>` | SharePoint sites & pages |
 | `/onedrive <query>` | OneDrive files |
 | `/onenote <query>` | OneNote pages |
-| `/task <query>` | Planner tasks |
+| `/task <query>` | Planner and Microsoft To Do tasks |
 | `/all <query>` | All enabled sources (same as no prefix) |
 | `/ask <instruction>` | Send pinned snippets to Microsoft 365 Copilot and open the reply in a new editor |
 | `/clear` | Clear the chat transcript and discard all pinned snippets |
@@ -40,7 +40,7 @@ ContextRelay is a VS Code extension that surfaces relevant Microsoft 365 context
 - Node.js 22 or later for local development and validation from source
 - [Visual Studio Code](https://code.visualstudio.com/) 1.85 or later
 - A Microsoft 365 work/school account (Microsoft Entra ID). Personal Microsoft accounts are not supported.
-- **For Exchange Mail, Teams, SharePoint, OneDrive, OneNote, and Planner search**: Standard Microsoft 365 license plus the required Microsoft Graph delegated permissions
+- **For Exchange Mail, Teams, SharePoint, OneDrive, OneNote, Planner, and Microsoft To Do search**: Standard Microsoft 365 license plus the required Microsoft Graph delegated permissions
 - **For Chat preview / Copilot-grounded features**: Microsoft 365 Copilot license might still be required depending on tenant rollout and API availability
 
 ### Required permissions
@@ -73,7 +73,7 @@ The following delegated Microsoft Graph permissions are required by feature:
 | `Chat.Read` | Teams search, Chat |
 | `ChannelMessage.Read.All` | Teams search, Chat |
 | `Notes.Read` | OneNote search |
-| `Tasks.Read` | Planner search |
+| `Tasks.Read` | Planner and Microsoft To Do task search |
 | `People.Read.All` | Chat |
 | `OnlineMeetingTranscript.Read.All` | Chat |
 | `ExternalItem.Read.All` | Connectors search, Chat (optional) |

--- a/package.json
+++ b/package.json
@@ -249,6 +249,11 @@
           "default": true,
           "description": "Enable Planner adapter"
         },
+        "contextRelay.adapters.todo": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable Microsoft To Do adapter"
+        },
         "contextRelay.adapters.connectors": {
           "type": "boolean",
           "default": false,

--- a/src/adapters/todoAdapter.ts
+++ b/src/adapters/todoAdapter.ts
@@ -1,0 +1,184 @@
+import * as vscode from 'vscode';
+import { ContextItem, GRAPH_BASE, graphFetchWithRetry, handleGraphResponse } from './graphClient';
+import { parseQueryIntent, scoreMatches } from './queryIntent';
+
+interface TodoTaskList {
+  id?: string;
+  displayName?: string;
+  wellknownListName?: string;
+}
+
+interface TodoTaskListResponse {
+  value?: TodoTaskList[];
+}
+
+interface TodoTaskBody {
+  content?: string;
+  contentType?: string;
+}
+
+interface TodoDateTimeTimeZone {
+  dateTime?: string;
+  timeZone?: string;
+}
+
+interface TodoTask {
+  id?: string;
+  title?: string;
+  status?: string;
+  importance?: string;
+  categories?: string[];
+  body?: TodoTaskBody;
+  createdDateTime?: string;
+  lastModifiedDateTime?: string;
+  dueDateTime?: TodoDateTimeTimeZone;
+}
+
+interface TodoTaskResponse {
+  value?: TodoTask[];
+}
+
+interface TodoCandidate {
+  task: TodoTask;
+  listName: string;
+  score: number;
+}
+
+export async function searchTodo(token: string, query: string): Promise<ContextItem[]> {
+  const config = vscode.workspace.getConfiguration('contextRelay');
+  const maxResults = config.get<number>('maxResults', 10);
+  const scanLimit = Math.min(Math.max(maxResults * 4, maxResults), 40);
+  const intent = parseQueryIntent(query);
+  const taskLists = await listTaskLists(token);
+  const taskListsWithTasks = await listTasksByList(token, taskLists, scanLimit);
+
+  const candidates = taskListsWithTasks.flatMap(({ list, tasks }) =>
+    tasks.map(task => {
+      const listName = list.displayName?.trim() || getFallbackListName(list);
+      const score = computeTodoScore(task, listName, intent.includePlannerMetadata, intent.searchTerms);
+      return { task, listName, score };
+    })
+  );
+
+  return candidates
+    .filter(candidate => intent.searchTerms.length === 0 || candidate.score > 0)
+    .sort(compareTodoCandidates)
+    .slice(0, maxResults)
+    .map(candidate => mapTodoCandidate(candidate, intent.includePlannerMetadata));
+}
+
+async function listTaskLists(token: string): Promise<TodoTaskList[]> {
+  const response = await graphFetchWithRetry(`${GRAPH_BASE}/v1.0/me/todo/lists`, token, { method: 'GET' });
+  const data = await handleGraphResponse(response) as TodoTaskListResponse;
+  return data.value?.filter(list => list.id) ?? [];
+}
+
+async function listTasksByList(
+  token: string,
+  lists: TodoTaskList[],
+  scanLimit: number
+): Promise<Array<{ list: TodoTaskList; tasks: TodoTask[] }>> {
+  return Promise.all(lists.map(async list => ({
+    list,
+    tasks: await listTasks(token, list.id as string, scanLimit)
+  })));
+}
+
+async function listTasks(token: string, listId: string, scanLimit: number): Promise<TodoTask[]> {
+  const url = `${GRAPH_BASE}/v1.0/me/todo/lists/${encodeURIComponent(listId)}/tasks?$top=${scanLimit}`;
+  const response = await graphFetchWithRetry(url, token, { method: 'GET' });
+  const data = await handleGraphResponse(response) as TodoTaskResponse;
+  return data.value?.filter(task => task.id) ?? [];
+}
+
+function computeTodoScore(
+  task: TodoTask,
+  listName: string,
+  includeMetadata: boolean,
+  searchTerms: string[]
+): number {
+  if (searchTerms.length === 0) {
+    return 0;
+  }
+
+  const titleScore = scoreMatches(task.title ?? '', searchTerms) * 4;
+  const bodyScore = scoreMatches(task.body?.content ?? '', searchTerms) * 3;
+  const metadataScore = includeMetadata
+    ? (
+      scoreMatches(listName, searchTerms) +
+      scoreMatches(task.status ?? '', searchTerms) +
+      scoreMatches(task.importance ?? '', searchTerms) +
+      scoreMatches((task.categories ?? []).join(' '), searchTerms)
+    ) * 2
+    : 0;
+
+  return titleScore + bodyScore + metadataScore;
+}
+
+function compareTodoCandidates(left: TodoCandidate, right: TodoCandidate): number {
+  if (right.score !== left.score) {
+    return right.score - left.score;
+  }
+
+  return compareIsoTimestamps(
+    left.task.dueDateTime?.dateTime ?? left.task.lastModifiedDateTime ?? left.task.createdDateTime,
+    right.task.dueDateTime?.dateTime ?? right.task.lastModifiedDateTime ?? right.task.createdDateTime
+  );
+}
+
+function mapTodoCandidate(candidate: TodoCandidate, includeMetadata: boolean): ContextItem {
+  const { task, listName } = candidate;
+  const body = task.body?.content?.trim() ?? '';
+  const snippetParts = [body || 'No task notes available.'];
+
+  if (includeMetadata) {
+    const metadataParts = [
+      listName ? `List: ${listName}` : undefined,
+      task.status ? `Status: ${task.status}` : undefined,
+      task.importance ? `Importance: ${task.importance}` : undefined,
+      formatDueDate(task.dueDateTime) ? `Due: ${formatDueDate(task.dueDateTime)}` : undefined
+    ].filter(Boolean);
+
+    if (metadataParts.length > 0) {
+      snippetParts.push(metadataParts.join(' · '));
+    }
+
+    if ((task.categories ?? []).length > 0) {
+      snippetParts.push(`Categories: ${task.categories?.join('; ')}`);
+    }
+  }
+
+  return {
+    source: 'todo',
+    title: task.title?.trim() || 'Untitled task',
+    snippet: snippetParts.join('\n'),
+    timestamp: task.dueDateTime?.dateTime ?? task.lastModifiedDateTime ?? task.createdDateTime,
+    cache: { hit: false },
+    raw: {
+      body,
+      listName,
+      wellknownListName: undefined,
+      status: task.status,
+      importance: task.importance,
+      categories: task.categories ?? []
+    }
+  };
+}
+
+function getFallbackListName(list: TodoTaskList): string {
+  return list.wellknownListName?.trim() || 'Task list';
+}
+
+function formatDueDate(value?: TodoDateTimeTimeZone): string | undefined {
+  const iso = value?.dateTime?.trim();
+  if (!iso) {
+    return undefined;
+  }
+
+  const parsed = Date.parse(iso);
+  return Number.isNaN(parsed) ? iso : new Date(parsed).toLocaleDateString();
+}
+
+function compareIsoTimestamps(left?: string, right?: string): number {
+  return (Date.parse(right ?? '') || 0) - (Date.parse(left ?? '') || 0);
+}

--- a/src/auth/authProvider.ts
+++ b/src/auth/authProvider.ts
@@ -41,7 +41,10 @@ export class AuthProvider {
     if (config.get<boolean>('adapters.onenote', true)) {
       ONENOTE_SCOPES.forEach(s => featureScopes.add(s));
     }
-    if (config.get<boolean>('adapters.planner', true)) {
+    if (
+      config.get<boolean>('adapters.planner', true) ||
+      config.get<boolean>('adapters.todo', true)
+    ) {
       PLANNER_SCOPES.forEach(s => featureScopes.add(s));
     }
     if (config.get<boolean>('adapters.connectors', false)) {

--- a/src/models/contextItem.ts
+++ b/src/models/contextItem.ts
@@ -5,6 +5,7 @@ export type ContextSource =
   | 'teams'
   | 'onenote'
   | 'planner'
+  | 'todo'
   | 'connectors';
 
 export interface ContextItem {

--- a/src/panel/chatViewProvider.ts
+++ b/src/panel/chatViewProvider.ts
@@ -1,12 +1,14 @@
 import * as crypto from 'crypto';
 import * as vscode from 'vscode';
 import { askCopilot } from '../adapters/chatAdapter';
+import { graphFetchWithRetry, handleGraphResponse, GRAPH_BASE } from '../adapters/graphClient';
 import { hydrateItemForHandoff } from '../adapters/handoffContentAdapter';
 import { searchMail } from '../adapters/mailAdapter';
 import { searchOneNote } from '../adapters/onenoteAdapter';
 import { searchPlanner } from '../adapters/plannerAdapter';
 import { searchRetrieval } from '../adapters/retrievalAdapter';
 import { searchTeams } from '../adapters/teamsAdapter';
+import { searchTodo } from '../adapters/todoAdapter';
 import { AuthProvider } from '../auth/authProvider';
 import { CacheStore } from '../cache/cacheStore';
 import { DocGenerator, type HandoffContext } from '../docs/docGenerator';
@@ -14,12 +16,14 @@ import { type ContextItem, type ContextSource, getContextItemKey } from '../mode
 import { type RouteTarget, getHelpText, parseCommand } from '../router/commandRouter';
 import { SnippetStore } from '../snippets/snippetStore';
 import { buildAskPrompt } from './askPrompt';
+import { createFallbackPreview, createMailPreview, getMailMessageId } from './itemPreview';
+import { buildPreviewDocument } from './openResult';
 import { detectOutputLanguage } from './outputLanguage';
 import { buildSearchSummary, type SearchSummaryResult } from './searchSummary';
 import { type HostToWebviewMessage, type WebviewToHostMessage } from './types';
 import { CHAT_EDITOR_PANEL_ID, CHAT_VIEW_ID } from './chatViewConstants';
 
-const DEFAULT_SOURCES: ContextSource[] = ['mail', 'teams', 'sharepoint', 'onedrive', 'onenote', 'planner'];
+const DEFAULT_SOURCES: ContextSource[] = ['mail', 'teams', 'sharepoint', 'onedrive', 'onenote', 'planner', 'todo'];
 type ChatHostKind = 'sidebar' | 'editor';
 
 interface ChatHostSession {
@@ -202,6 +206,9 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
         break;
       case 'openLink':
         await this.handleOpenLink(message.url);
+        break;
+      case 'openItem':
+        await this.handleOpenItem(message.item);
         break;
       case 'copySnippet':
         await this.handleCopySnippet(message.text);
@@ -483,6 +490,11 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
   }
 
   private getTargetSources(target: RouteTarget): ContextSource[] {
+    if (target === 'task') {
+      const taskSources: ContextSource[] = ['planner', 'todo'];
+      return taskSources.filter(source => this.isSourceEnabled(source));
+    }
+
     if (target === 'ask' || target === 'all') {
       const sources = DEFAULT_SOURCES.filter(source => this.isSourceEnabled(source));
       if (this.isSourceEnabled('connectors')) {
@@ -513,9 +525,41 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
         return config.get<boolean>('adapters.onenote', true);
       case 'planner':
         return config.get<boolean>('adapters.planner', true);
+      case 'todo':
+        return config.get<boolean>('adapters.todo', true);
       case 'connectors':
         return config.get<boolean>('adapters.connectors', false);
     }
+  }
+
+  private async handleOpenItem(item: ContextItem): Promise<void> {
+    if (!item) {
+      return;
+    }
+
+    if (item.url?.trim()) {
+      await this.handleOpenLink(item.url);
+      return;
+    }
+
+    let preview = createFallbackPreview(item);
+
+    if (item.source === 'mail') {
+      const token = await this.authProvider.getAccessToken();
+      const messageId = getMailMessageId(item);
+      if (messageId) {
+        const url = `${GRAPH_BASE}/v1.0/me/messages/${encodeURIComponent(messageId)}?$select=body`;
+        const response = await graphFetchWithRetry(url, token, { method: 'GET' });
+        const data = await handleGraphResponse(response) as { body?: { contentType?: string; content?: string } };
+        preview = createMailPreview(item, data);
+      }
+    }
+
+    const doc = await vscode.workspace.openTextDocument({
+      language: 'markdown',
+      content: buildPreviewDocument(preview)
+    });
+    await vscode.window.showTextDocument(doc, { preview: false });
   }
 
   private async fetchResults(
@@ -590,6 +634,12 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
           `planner:${query}`,
           config.get<boolean>('adapters.planner', true),
           () => searchPlanner(token, query)
+        );
+      case 'todo':
+        return runCachedSearch(
+          `todo:${query}`,
+          config.get<boolean>('adapters.todo', true),
+          () => searchTodo(token, query)
         );
       case 'connectors':
         return runCachedSearch(

--- a/src/panel/itemPreview.ts
+++ b/src/panel/itemPreview.ts
@@ -25,6 +25,12 @@ interface PlannerItemRaw {
   bucketName?: string;
 }
 
+interface TodoItemRaw {
+  body?: string;
+  listName?: string;
+  status?: string;
+}
+
 interface RetrievalItemRaw {
   extracts?: string[];
 }
@@ -82,6 +88,18 @@ export function createFallbackPreview(item: ContextItem): ResolvedPreview {
     case 'planner': {
       const raw = asPlannerItemRaw(item.raw);
       const subtitle = [raw?.planTitle, raw?.bucketName].filter(Boolean).join(' · ');
+      return {
+        source: item.source,
+        title: item.title,
+        subtitle: subtitle || undefined,
+        body,
+        timestamp: item.timestamp,
+        url: item.url
+      };
+    }
+    case 'todo': {
+      const raw = asTodoItemRaw(item.raw);
+      const subtitle = [raw?.listName, raw?.status].filter(Boolean).join(' · ');
       return {
         source: item.source,
         title: item.title,
@@ -166,6 +184,13 @@ function getFallbackBody(item: ContextItem): string {
     }
   }
 
+  if (item.source === 'todo') {
+    const body = asTodoItemRaw(item.raw)?.body;
+    if (body) {
+      return normalizePreviewText(body) || 'No preview text is available for this item yet.';
+    }
+  }
+
   return normalizePreviewText(item.snippet) || 'No preview text is available for this item yet.';
 }
 
@@ -233,6 +258,10 @@ function asOneNoteItemRaw(raw: unknown): OneNoteItemRaw | undefined {
 
 function asPlannerItemRaw(raw: unknown): PlannerItemRaw | undefined {
   return raw && typeof raw === 'object' ? raw as PlannerItemRaw : undefined;
+}
+
+function asTodoItemRaw(raw: unknown): TodoItemRaw | undefined {
+  return raw && typeof raw === 'object' ? raw as TodoItemRaw : undefined;
 }
 
 function asRetrievalItemRaw(raw: unknown): RetrievalItemRaw | undefined {

--- a/src/panel/openResult.ts
+++ b/src/panel/openResult.ts
@@ -1,0 +1,27 @@
+import { ContextItem, ResolvedPreview } from '../models/contextItem';
+import { getSourceLabel } from '../sourcePresentation';
+
+const INTERNAL_PREVIEW_SOURCES = new Set<ContextItem['source']>(['planner', 'todo']);
+
+export function canOpenResult(item: Pick<ContextItem, 'source' | 'url'>): boolean {
+  return Boolean(item.url?.trim()) || INTERNAL_PREVIEW_SOURCES.has(item.source);
+}
+
+export function buildPreviewDocument(preview: ResolvedPreview): string {
+  const lines = [`# ${preview.title}`, ''];
+  const metadata: string[] = [
+    `- Source: ${getSourceLabel(preview.source)}`,
+    preview.subtitle ? `- Context: ${preview.subtitle}` : undefined,
+    preview.timestamp ? `- Timestamp: ${preview.timestamp}` : undefined,
+    preview.url ? `- Link: ${preview.url}` : undefined
+  ].filter((value): value is string => Boolean(value));
+
+  lines.push(...metadata);
+
+  if (metadata.length > 0) {
+    lines.push('');
+  }
+
+  lines.push(preview.body || 'No preview text is available for this item yet.');
+  return lines.join('\n');
+}

--- a/src/panel/panelProvider.ts
+++ b/src/panel/panelProvider.ts
@@ -11,6 +11,7 @@ import { searchOneNote } from '../adapters/onenoteAdapter';
 import { searchPlanner } from '../adapters/plannerAdapter';
 import { searchTeams } from '../adapters/teamsAdapter';
 import { searchRetrieval } from '../adapters/retrievalAdapter';
+import { searchTodo } from '../adapters/todoAdapter';
 import { createConversation, sendMessage } from '../adapters/chatAdapter';
 import { ContextItem } from '../models/contextItem';
 import { hydrateItemForHandoff } from '../adapters/handoffContentAdapter';
@@ -284,9 +285,13 @@ export class PanelProvider implements vscode.WebviewViewProvider {
       const enabled = config.get<boolean>('adapters.onenote', true);
       promises.push(runAdapter('onenote', enabled, `onenote:${q}`, () => searchOneNote(token, q)));
     }
-    if (runAll || target === 'planner') {
+    if (runAll || target === 'planner' || target === 'task') {
       const enabled = config.get<boolean>('adapters.planner', true);
       promises.push(runAdapter('planner', enabled, `planner:${q}`, () => searchPlanner(token, q)));
+    }
+    if (runAll || target === 'task') {
+      const enabled = config.get<boolean>('adapters.todo', true);
+      promises.push(runAdapter('todo', enabled, `todo:${q}`, () => searchTodo(token, q)));
     }
     if (runAll && config.get<boolean>('adapters.connectors', false)) {
       promises.push(runAdapter('connectors', true, `connectors:${q}`, () =>

--- a/src/panel/slashCommandRouter.ts
+++ b/src/panel/slashCommandRouter.ts
@@ -10,7 +10,7 @@ export interface ParsedCommand {
   targetSources: ContextSource[];
 }
 
-const ALL_SOURCES: ContextSource[] = ['sharepoint', 'onedrive', 'onenote', 'planner', 'mail', 'teams'];
+const ALL_SOURCES: ContextSource[] = ['sharepoint', 'onedrive', 'onenote', 'planner', 'todo', 'mail', 'teams'];
 
 /**
  * Parse user input and route to the appropriate adapter(s).
@@ -45,7 +45,9 @@ export function parseSlashCommand(input: string): ParsedCommand {
   }
 
   const targetSources: ContextSource[] =
-    matched.source === 'all' || !matched.source
+    matched.sources?.length
+      ? matched.sources
+      : matched.source === 'all' || !matched.source
       ? ALL_SOURCES
       : [matched.source];
 

--- a/src/panel/types.ts
+++ b/src/panel/types.ts
@@ -17,6 +17,7 @@ export interface SlashCommand {
   description: string;
   icon: string;
   source?: ContextSource | 'all';
+  sources?: ContextSource[];
 }
 
 export const SLASH_COMMANDS: SlashCommand[] = [
@@ -25,7 +26,7 @@ export const SLASH_COMMANDS: SlashCommand[] = [
   { command: '/sharepoint', label: '/sharepoint', description: 'Search SharePoint', icon: '📄', source: 'sharepoint' },
   { command: '/onedrive', label: '/onedrive', description: 'Search OneDrive', icon: '☁️', source: 'onedrive' },
   { command: '/onenote', label: '/onenote', description: 'Search OneNote pages', icon: '🗒️', source: 'onenote' },
-  { command: '/task', label: '/task', description: 'Search Planner tasks', icon: '✅', source: 'planner' },
+  { command: '/task', label: '/task', description: 'Search Planner and Microsoft To Do tasks', icon: '☑️', sources: ['planner', 'todo'] },
   { command: '/all', label: '/all', description: 'Search all sources', icon: '🔍', source: 'all' },
   { command: '/ask', label: '/ask', description: 'Ask Microsoft 365 Copilot using pinned snippets as context', icon: '🤖' },
   { command: '/clear', label: '/clear', description: 'Clear chat and discard pinned snippets', icon: '🧹' },
@@ -52,6 +53,11 @@ export interface OpenLinkMessage {
   url: string;
 }
 
+export interface OpenItemMessage {
+  command: 'openItem';
+  item: ContextItem;
+}
+
 export interface CopySnippetMessage {
   command: 'copySnippet';
   text: string;
@@ -62,6 +68,7 @@ export type WebviewToHostMessage =
   | WebviewReadyMessage
   | PinSnippetMessage
   | OpenLinkMessage
+  | OpenItemMessage
   | CopySnippetMessage;
 
 // --- Messages: Extension host → Webview ---

--- a/src/router/commandRouter.ts
+++ b/src/router/commandRouter.ts
@@ -5,6 +5,7 @@ export type RouteTarget =
   | 'onedrive'
   | 'onenote'
   | 'planner'
+  | 'task'
   | 'all'
   | 'ask'
   | 'clear';
@@ -21,7 +22,7 @@ const SLASH_COMMANDS: Record<string, RouteTarget> = {
   sharepoint: 'sharepoint',
   onedrive: 'onedrive',
   onenote: 'onenote',
-  task: 'planner',
+  task: 'task',
   all: 'all',
   ask: 'ask',
   clear: 'clear'
@@ -67,6 +68,7 @@ export function getHelpText(command: string): string {
     onedrive: 'Example: /onedrive architecture diagram\nExample: /onedrive Q3 report',
     onenote: 'Example: /onenote architecture decision log\nExample: /onenote section notebook architecture',
     planner: 'Example: /task release checklist\nExample: /task metadata comments onboarding',
+    task: 'Example: /task release checklist\nExample: /task metadata comments onboarding',
     all: 'Example: /all architecture decisions\nOr just type a query without a slash command.',
     ask: 'Example: /ask 日本語に翻訳してmarkdownにして\nExample: /ask Summarize the pinned docs as a bullet list\nPinned snippets are used as context and the Microsoft 365 Copilot response is opened in a new editor tab.',
     clear: 'Example: /clear\nClears the current chat transcript and discards all pinned snippets.'

--- a/src/sourcePresentation.ts
+++ b/src/sourcePresentation.ts
@@ -18,6 +18,7 @@ export const SOURCE_TEXT_ICONS: Record<DisplaySource, string> = {
   onedrive: '☁️',
   onenote: '🗒️',
   planner: '✅',
+  todo: '☑️',
   connectors: '🔗',
   all: '🔍'
 };
@@ -29,6 +30,7 @@ export const SOURCE_LABELS: Record<DisplaySource, string> = {
   onedrive: 'OneDrive',
   onenote: 'OneNote',
   planner: 'Planner',
+  todo: 'Microsoft To Do',
   connectors: 'Connectors',
   all: 'All Sources'
 };

--- a/src/test/suite/authProvider.test.ts
+++ b/src/test/suite/authProvider.test.ts
@@ -48,6 +48,7 @@ suite('AuthProvider', () => {
     configValues.set('adapters.teams', false);
     configValues.set('adapters.sharepoint', false);
     configValues.set('adapters.onedrive', false);
+    configValues.set('adapters.todo', false);
     configValues.set('adapters.connectors', false);
   });
 
@@ -62,9 +63,21 @@ suite('AuthProvider', () => {
     assert.ok(scopes.includes('https://graph.microsoft.com/Tasks.Read'));
   });
 
-  test('omits Notes.Read and Tasks.Read when OneNote and Planner are disabled', () => {
+  test('includes Tasks.Read when Microsoft To Do is enabled without Planner', () => {
     configValues.set('adapters.onenote', false);
     configValues.set('adapters.planner', false);
+    configValues.set('adapters.todo', true);
+
+    const provider = new AuthProvider({} as never);
+    const scopes = provider.getRequiredScopes();
+
+    assert.ok(scopes.includes('https://graph.microsoft.com/Tasks.Read'));
+  });
+
+  test('omits Notes.Read and Tasks.Read when OneNote, Planner, and To Do are disabled', () => {
+    configValues.set('adapters.onenote', false);
+    configValues.set('adapters.planner', false);
+    configValues.set('adapters.todo', false);
 
     const provider = new AuthProvider({} as never);
     const scopes = provider.getRequiredScopes();

--- a/src/test/suite/commandRouter.test.ts
+++ b/src/test/suite/commandRouter.test.ts
@@ -40,9 +40,9 @@ suite('CommandRouter', () => {
     assert.equal(result.query, 'architecture decision log');
   });
 
-  test('/task command routes to planner', () => {
+  test('/task command routes to combined task search', () => {
     const result = parseCommand('/task release checklist');
-    assert.equal(result.target, 'planner');
+    assert.equal(result.target, 'task');
     assert.equal(result.query, 'release checklist');
   });
 
@@ -102,9 +102,9 @@ suite('CommandRouter', () => {
     assert.ok(text.includes('Example'));
   });
 
-  test('getHelpText returns onboarding examples for onenote and planner', () => {
+  test('getHelpText returns onboarding examples for onenote and task search', () => {
     assert.ok(getHelpText('onenote').includes('/onenote'));
-    assert.ok(getHelpText('planner').includes('/task'));
+    assert.ok(getHelpText('task').includes('/task'));
   });
 
   test('getHelpText returns fallback for unknown command', () => {

--- a/src/test/suite/itemPreview.test.ts
+++ b/src/test/suite/itemPreview.test.ts
@@ -92,4 +92,19 @@ suite('Item preview', () => {
     assert.equal(preview.subtitle, 'Release train · Ready');
     assert.equal(preview.body, 'Task description');
   });
+
+  test('includes To Do metadata in preview subtitle when available', () => {
+    const preview = createFallbackPreview(makeItem({
+      source: 'todo',
+      snippet: 'Need milk and fruit',
+      raw: {
+        body: 'Need milk and fruit',
+        listName: 'Personal',
+        status: 'notStarted'
+      }
+    }));
+
+    assert.equal(preview.subtitle, 'Personal · notStarted');
+    assert.equal(preview.body, 'Need milk and fruit');
+  });
 });

--- a/src/test/suite/openResult.test.ts
+++ b/src/test/suite/openResult.test.ts
@@ -1,0 +1,29 @@
+import { strict as assert } from 'assert';
+import { buildPreviewDocument, canOpenResult } from '../../panel/openResult';
+
+suite('Open result', () => {
+  test('shows open action for task results without external URLs', () => {
+    assert.equal(canOpenResult({ source: 'planner' }), true);
+    assert.equal(canOpenResult({ source: 'todo' }), true);
+    assert.equal(canOpenResult({ source: 'mail' }), false);
+  });
+
+  test('shows open action for any result that already has a URL', () => {
+    assert.equal(canOpenResult({ source: 'mail', url: 'https://example.com' }), true);
+  });
+
+  test('builds a readable markdown preview document', () => {
+    const content = buildPreviewDocument({
+      source: 'todo',
+      title: 'Buy groceries',
+      subtitle: 'Personal · notStarted',
+      body: 'Need milk and fruit',
+      timestamp: '2026-04-30T00:00:00Z'
+    });
+
+    assert.ok(content.includes('# Buy groceries'));
+    assert.ok(content.includes('- Source: Microsoft To Do'));
+    assert.ok(content.includes('- Context: Personal · notStarted'));
+    assert.ok(content.includes('Need milk and fruit'));
+  });
+});

--- a/src/test/suite/todoAdapter.test.ts
+++ b/src/test/suite/todoAdapter.test.ts
@@ -1,0 +1,100 @@
+import { strict as assert } from 'assert';
+import Module from 'module';
+
+type SearchTodoFn = typeof import('../../adapters/todoAdapter').searchTodo;
+type ModuleLoader = typeof Module & {
+  _load: (request: string, parent: object | null | undefined, isMain: boolean) => unknown;
+};
+
+const moduleLoader = Module as unknown as ModuleLoader;
+const originalLoad = moduleLoader._load;
+let searchTodo: SearchTodoFn;
+
+suite('To Do adapter', () => {
+  suiteSetup(async () => {
+    moduleLoader._load = (request: string, parent: object | null | undefined, isMain: boolean): unknown => {
+      if (request === 'vscode') {
+        return {
+          workspace: {
+            getConfiguration: () => ({
+              get: <T>(_key: string, defaultValue: T): T => defaultValue
+            })
+          }
+        };
+      }
+
+      return originalLoad(request, parent, isMain);
+    };
+
+    try {
+      ({ searchTodo } = await import('../../adapters/todoAdapter'));
+    } finally {
+      moduleLoader._load = originalLoad;
+    }
+  });
+
+  test('returns personal task results with To Do metadata when requested', async () => {
+    const originalFetch = globalThis.fetch;
+
+    globalThis.fetch = (async (input: Parameters<typeof fetch>[0]): Promise<Response> => {
+      const url = typeof input === 'string' ? input : input.toString();
+      if (url.includes('/v1.0/me/todo/lists/list-1/tasks?')) {
+        return jsonResponse({
+          value: [
+            {
+              id: 'todo-1',
+              title: 'Buy groceries',
+              status: 'notStarted',
+              importance: 'high',
+              categories: ['Errands'],
+              createdDateTime: '2026-04-01T00:00:00Z',
+              dueDateTime: {
+                dateTime: '2026-04-30T00:00:00Z',
+                timeZone: 'UTC'
+              },
+              body: {
+                contentType: 'text',
+                content: 'Need milk and fruit'
+              }
+            }
+          ]
+        });
+      }
+
+      if (url.endsWith('/v1.0/me/todo/lists')) {
+        return jsonResponse({
+          value: [
+            {
+              id: 'list-1',
+              displayName: 'Personal'
+            }
+          ]
+        });
+      }
+
+      throw new Error(`Unexpected fetch URL: ${url}`);
+    }) as typeof fetch;
+
+    try {
+      const items = await searchTodo('token', 'metadata groceries');
+
+      assert.equal(items.length, 1);
+      assert.equal(items[0].source, 'todo');
+      assert.equal(items[0].title, 'Buy groceries');
+      assert.ok(items[0].snippet.includes('Need milk and fruit'));
+      assert.ok(items[0].snippet.includes('List: Personal'));
+      assert.ok(items[0].snippet.includes('Status: notStarted'));
+      assert.ok(items[0].snippet.includes('Importance: high'));
+      assert.ok(items[0].snippet.includes('Categories: Errands'));
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' }
+  });
+}

--- a/src/webview/chatRenderer.ts
+++ b/src/webview/chatRenderer.ts
@@ -6,9 +6,10 @@
  */
 
 import { getSourceInlineSvg, getSourceLabel, getSourceTextIcon } from '../sourcePresentation';
+import { canOpenResult } from '../panel/openResult';
 
 interface ContextItem {
-  source: 'sharepoint' | 'onedrive' | 'mail' | 'teams' | 'onenote' | 'planner' | 'connectors';
+  source: 'sharepoint' | 'onedrive' | 'mail' | 'teams' | 'onenote' | 'planner' | 'todo' | 'connectors';
   title: string;
   snippet: string;
   url?: string;
@@ -385,13 +386,18 @@ export class ChatRenderer {
     const actionsDiv = document.createElement('div');
     actionsDiv.className = 'actions';
 
-    if (item.url) {
+    if (canOpenResult(item)) {
       const openBtn = document.createElement('button');
       openBtn.className = 'action-open';
-      openBtn.title = 'Open in browser';
+      openBtn.title = item.url ? 'Open in browser' : 'Open preview';
       openBtn.textContent = 'Open';
       openBtn.addEventListener('click', () => {
-        this.vscode.postMessage({ command: 'openLink', url: item.url });
+        if (item.url) {
+          this.vscode.postMessage({ command: 'openLink', url: item.url });
+          return;
+        }
+
+        this.vscode.postMessage({ command: 'openItem', item });
       });
       actionsDiv.appendChild(openBtn);
     }

--- a/src/webview/main.ts
+++ b/src/webview/main.ts
@@ -106,7 +106,7 @@ interface HostMessage {
 }
 
 interface ContextItem {
-  source: 'sharepoint' | 'onedrive' | 'mail' | 'teams' | 'onenote' | 'planner' | 'connectors';
+  source: 'sharepoint' | 'onedrive' | 'mail' | 'teams' | 'onenote' | 'planner' | 'todo' | 'connectors';
   title: string;
   snippet: string;
   url?: string;

--- a/src/webview/slashMenu.ts
+++ b/src/webview/slashMenu.ts
@@ -10,7 +10,7 @@ interface SlashMenuItem {
   label: string;
   description: string;
   icon: string;
-  sourceIcon?: 'mail' | 'teams' | 'sharepoint' | 'onedrive' | 'onenote' | 'planner' | 'all';
+  sourceIcon?: 'mail' | 'teams' | 'sharepoint' | 'onedrive' | 'onenote' | 'planner' | 'todo' | 'all';
 }
 
 const SLASH_ITEMS: SlashMenuItem[] = [
@@ -19,7 +19,7 @@ const SLASH_ITEMS: SlashMenuItem[] = [
   { command: '/sharepoint', label: '/sharepoint', description: 'Search SharePoint', icon: getSourceTextIcon('sharepoint'), sourceIcon: 'sharepoint' },
   { command: '/onedrive', label: '/onedrive', description: 'Search OneDrive', icon: getSourceTextIcon('onedrive'), sourceIcon: 'onedrive' },
   { command: '/onenote', label: '/onenote', description: 'Search OneNote pages', icon: getSourceTextIcon('onenote'), sourceIcon: 'onenote' },
-  { command: '/task', label: '/task', description: 'Search Planner tasks', icon: getSourceTextIcon('planner'), sourceIcon: 'planner' },
+  { command: '/task', label: '/task', description: 'Search Planner and Microsoft To Do tasks', icon: getSourceTextIcon('todo'), sourceIcon: 'todo' },
   { command: '/all', label: '/all', description: 'Search all sources', icon: getSourceTextIcon('all'), sourceIcon: 'all' },
   { command: '/ask', label: '/ask', description: 'Ask Microsoft 365 Copilot using pinned snippets', icon: '🤖' },
   { command: '/clear', label: '/clear', description: 'Clear chat and discard pinned snippets', icon: '🧹' },


### PR DESCRIPTION
## Why
`/task` only searched Planner tasks, so personal Microsoft To Do items were missing from task search. Task results also did not show the Open action when no external browser URL was available, which made `/task` behave differently from the other sources.

## What changed
- add a dedicated Microsoft To Do adapter and include it in `/task` and `/all`
- extend source metadata, settings, auth scope handling, and slash-command descriptions for the new `todo` source
- keep Planner and To Do task scoring aligned with the existing query intent helpers
- show the Open action for Planner and To Do results by opening an internal markdown preview when no external URL exists

## Notes for reviewers
The Open action fallback is intentional. Planner and Microsoft To Do task results do not expose the same browser URL shape as mail, Teams, SharePoint, or OneNote, so the task sources now open an internal preview document instead of hiding the action.

## Validation
- `npm run compile`
- `npm run lint`
- `npm test`
- `npm run security:check`

Closes #34
Closes #35