### PR TITLE
Support multi-source slash command searches

### DIFF
--- a/src/panel/chatViewProvider.ts
+++ b/src/panel/chatViewProvider.ts
@@ -13,7 +13,7 @@ import { AuthProvider } from '../auth/authProvider';
 import { CacheStore } from '../cache/cacheStore';
 import { DocGenerator, type HandoffContext } from '../docs/docGenerator';
 import { type ContextItem, type ContextSource, getContextItemKey } from '../models/contextItem';
-import { type RouteTarget, getHelpText, parseCommand } from '../router/commandRouter';
+import { getHelpText, parseCommand } from '../router/commandRouter';
 import { SnippetStore } from '../snippets/snippetStore';
 import { buildAskPrompt } from './askPrompt';
 import { createFallbackPreview, createMailPreview, getMailMessageId } from './itemPreview';
@@ -23,7 +23,6 @@ import { buildSearchSummary, type SearchSummaryResult } from './searchSummary';
 import { type HostToWebviewMessage, type WebviewToHostMessage } from './types';
 import { CHAT_EDITOR_PANEL_ID, CHAT_VIEW_ID } from './chatViewConstants';
 
-const DEFAULT_SOURCES: ContextSource[] = ['mail', 'teams', 'sharepoint', 'onedrive', 'onenote', 'planner', 'todo'];
 type ChatHostKind = 'sidebar' | 'editor';
 
 interface ChatHostSession {
@@ -313,11 +312,11 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
     const parsed = parseCommand(text);
     if (parsed.isEmpty) {
       if (trimmed.startsWith('/')) {
-        const requestedCommand = trimmed.split(/\s+/, 1)[0] || `/${parsed.target}`;
+        const requestedCommand = parsed.commandText ?? (trimmed.split(/\s+/, 1)[0] || `/${parsed.target}`);
         this.postMessage({
           command: 'slashHelp',
           commandName: requestedCommand,
-          examples: getHelpText(parsed.target)
+          examples: getHelpText(parsed.sourceCommands.length > 0 ? parsed.sourceCommands : parsed.target)
             .split('\n')
             .map(example => example.trim())
             .filter(Boolean)
@@ -336,10 +335,10 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
       return;
     }
 
-    const targetSources = this.getTargetSources(parsed.target);
+    const targetSources = this.getEnabledTargetSources(parsed.targetSources, parsed.searchScope === 'all');
     if (targetSources.length === 0) {
       const message = 'No ContextRelay adapters are enabled.';
-      this.latestSearchSummary = buildSearchSummary(parsed.query, []);
+      this.latestSearchSummary = buildSearchSummary(parsed.query, [], parsed.targetSources);
       this.postMessage({
         command: 'queryError',
         source: 'all',
@@ -361,7 +360,7 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
           items: [],
           error: message
         }
-      ]);
+      ], parsed.targetSources);
       this.postMessage({
         command: 'queryError',
         source: errorSource,
@@ -382,7 +381,7 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
     const results = await Promise.all(
       targetSources.map(source => this.querySource(source, parsed.query, token))
     );
-    this.latestSearchSummary = buildSearchSummary(parsed.query, results);
+    this.latestSearchSummary = buildSearchSummary(parsed.query, results, targetSources);
   }
 
   private async querySource(
@@ -505,25 +504,15 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
     }
   }
 
-  private getTargetSources(target: RouteTarget): ContextSource[] {
-    if (target === 'task') {
-      const taskSources: ContextSource[] = ['planner', 'todo'];
-      return taskSources.filter(source => this.isSourceEnabled(source));
+  private getEnabledTargetSources(
+    requestedSources: readonly ContextSource[],
+    includeConnectors: boolean
+  ): ContextSource[] {
+    const sources = requestedSources.filter(source => this.isSourceEnabled(source));
+    if (includeConnectors && this.isSourceEnabled('connectors')) {
+      sources.push('connectors');
     }
-
-    if (target === 'ask' || target === 'all') {
-      const sources = DEFAULT_SOURCES.filter(source => this.isSourceEnabled(source));
-      if (this.isSourceEnabled('connectors')) {
-        sources.push('connectors');
-      }
-      return target === 'all' ? sources : [];
-    }
-
-    if (target === 'clear') {
-      return [];
-    }
-
-    return [target];
+    return sources;
   }
 
   private isSourceEnabled(source: ContextSource): boolean {

--- a/src/panel/panelProvider.ts
+++ b/src/panel/panelProvider.ts
@@ -308,7 +308,7 @@ export class PanelProvider implements vscode.WebviewViewProvider {
     const summarySources = runAll && config.get<boolean>('adapters.connectors', false)
       ? [...parsed.targetSources, 'connectors']
       : parsed.targetSources;
-    this.latestSearchSummary = buildSearchSummary(query, results, summarySources);
+    this.latestSearchSummary = buildSearchSummary(parsed.query, results, summarySources);
 
     this.postMessage({ type: 'searchResults', results });
   }

--- a/src/panel/panelProvider.ts
+++ b/src/panel/panelProvider.ts
@@ -195,7 +195,7 @@ export class PanelProvider implements vscode.WebviewViewProvider {
     if (parsed.isEmpty) {
       this.postMessage({
         type: 'help',
-        text: getHelpText(parsed.target)
+        text: getHelpText(parsed.sourceCommands.length > 0 ? parsed.sourceCommands : parsed.target)
       });
       return;
     }
@@ -258,38 +258,38 @@ export class PanelProvider implements vscode.WebviewViewProvider {
       }
     };
 
-    const { target, query: q } = parsed;
-
-    const runAll = target === 'all';
+    const { query: q } = parsed;
+    const selectedSources = new Set(parsed.targetSources);
+    const runAll = parsed.searchScope === 'all';
     const promises: Promise<SearchResult>[] = [];
 
-    if (runAll || target === 'mail') {
+    if (selectedSources.has('mail')) {
       const enabled = config.get<boolean>('adapters.mail', true);
       promises.push(runAdapter('mail', enabled, `mail:${q}`, () => searchMail(token, q)));
     }
-    if (runAll || target === 'teams') {
+    if (selectedSources.has('teams')) {
       const enabled = config.get<boolean>('adapters.teams', true);
       promises.push(runAdapter('teams', enabled, `teams:${q}`, () => searchTeams(token, q)));
     }
-    if (runAll || target === 'sharepoint') {
+    if (selectedSources.has('sharepoint')) {
       const enabled = config.get<boolean>('adapters.sharepoint', true);
       promises.push(runAdapter('sharepoint', enabled, `sharepoint:${q}`, () =>
         searchRetrieval(token, q, 'sharePoint')));
     }
-    if (runAll || target === 'onedrive') {
+    if (selectedSources.has('onedrive')) {
       const enabled = config.get<boolean>('adapters.onedrive', true);
       promises.push(runAdapter('onedrive', enabled, `onedrive:${q}`, () =>
         searchRetrieval(token, q, 'oneDriveBusiness')));
     }
-    if (runAll || target === 'onenote') {
+    if (selectedSources.has('onenote')) {
       const enabled = config.get<boolean>('adapters.onenote', true);
       promises.push(runAdapter('onenote', enabled, `onenote:${q}`, () => searchOneNote(token, q)));
     }
-    if (runAll || target === 'planner' || target === 'task') {
+    if (selectedSources.has('planner')) {
       const enabled = config.get<boolean>('adapters.planner', true);
       promises.push(runAdapter('planner', enabled, `planner:${q}`, () => searchPlanner(token, q)));
     }
-    if (runAll || target === 'task') {
+    if (selectedSources.has('todo')) {
       const enabled = config.get<boolean>('adapters.todo', true);
       promises.push(runAdapter('todo', enabled, `todo:${q}`, () => searchTodo(token, q)));
     }
@@ -305,7 +305,10 @@ export class PanelProvider implements vscode.WebviewViewProvider {
       }
     }
 
-    this.latestSearchSummary = buildSearchSummary(query, results);
+    const summarySources = runAll && config.get<boolean>('adapters.connectors', false)
+      ? [...parsed.targetSources, 'connectors']
+      : parsed.targetSources;
+    this.latestSearchSummary = buildSearchSummary(query, results, summarySources);
 
     this.postMessage({ type: 'searchResults', results });
   }

--- a/src/panel/searchSummary.ts
+++ b/src/panel/searchSummary.ts
@@ -8,12 +8,22 @@ export interface SearchSummaryResult {
   cached?: boolean;
 }
 
-export function buildSearchSummary(query: string, results: SearchSummaryResult[]): string {
+export function buildSearchSummary(
+  query: string,
+  results: SearchSummaryResult[],
+  requestedSources: readonly string[] = []
+): string {
   const trimmedQuery = query.trim();
   const lines: string[] = [
     `Latest search query: \`${trimmedQuery}\``,
     ''
   ];
+
+  const uniqueSources = [...new Set(requestedSources)];
+  if (uniqueSources.length > 0) {
+    lines.push(`Requested sources: ${uniqueSources.map(capitalizeSource).join(', ')}`);
+    lines.push('');
+  }
 
   if (results.length === 0) {
     lines.push('- No sources were queried.');

--- a/src/router/commandRouter.ts
+++ b/src/router/commandRouter.ts
@@ -1,3 +1,5 @@
+import type { ContextSource } from '../models/contextItem';
+
 export type RouteTarget =
   | 'mail'
   | 'teams'
@@ -10,20 +12,32 @@ export type RouteTarget =
   | 'ask'
   | 'clear';
 
+export type SearchCommandName = 'mail' | 'teams' | 'sharepoint' | 'onedrive' | 'onenote' | 'task' | 'all';
+export type SearchScope = 'all' | 'scoped' | 'operation';
+
 export interface ParsedCommand {
   target: RouteTarget;
   query: string;
   isEmpty: boolean;
+  targetSources: ContextSource[];
+  sourceCommands: SearchCommandName[];
+  commandText?: string;
+  searchScope: SearchScope;
 }
 
-const SLASH_COMMANDS: Record<string, RouteTarget> = {
-  mail: 'mail',
-  teams: 'teams',
-  sharepoint: 'sharepoint',
-  onedrive: 'onedrive',
-  onenote: 'onenote',
-  task: 'task',
-  all: 'all',
+const ALL_SOURCES: ContextSource[] = ['mail', 'teams', 'sharepoint', 'onedrive', 'onenote', 'planner', 'todo'];
+
+const SEARCH_COMMAND_METADATA: Record<SearchCommandName, { target: RouteTarget; sources: ContextSource[] }> = {
+  mail: { target: 'mail', sources: ['mail'] },
+  teams: { target: 'teams', sources: ['teams'] },
+  sharepoint: { target: 'sharepoint', sources: ['sharepoint'] },
+  onedrive: { target: 'onedrive', sources: ['onedrive'] },
+  onenote: { target: 'onenote', sources: ['onenote'] },
+  task: { target: 'task', sources: ['planner', 'todo'] },
+  all: { target: 'all', sources: ALL_SOURCES }
+};
+
+const OPERATION_COMMANDS: Record<string, RouteTarget> = {
   ask: 'ask',
   clear: 'clear'
 };
@@ -36,31 +50,126 @@ export function parseCommand(input: string): ParsedCommand {
   const trimmed = input.trim();
   const normalized = normalizeQuery(trimmed);
 
-  if (trimmed.startsWith('/')) {
-    const commandMatch = trimmed.match(/^\/(\S+)(?:\s+([\s\S]*))?$/);
-    const command = commandMatch?.[1]?.toLowerCase() ?? trimmed.slice(1).toLowerCase();
-    const rawQuery = commandMatch?.[2] ?? '';
-    // For /ask, preserve newlines in the user's instruction so the prompt keeps its original shape.
-    const target = SLASH_COMMANDS[command];
-    const query = target === 'ask'
-      ? rawQuery.trim()
-      : target === 'clear'
-        ? ''
-        : normalizeQuery(rawQuery);
-
-    if (target) {
-      // /clear takes no arguments and is never treated as empty so it always executes.
-      const isEmpty = target === 'clear' ? false : query.length === 0;
-      return { target, query, isEmpty };
-    }
-    // Unknown slash command — treat as /all with the original input
-    return { target: 'all', query: normalized, isEmpty: normalized.length === 0 };
+  if (!trimmed.startsWith('/')) {
+    return {
+      target: 'all',
+      query: normalized,
+      isEmpty: normalized.length === 0,
+      targetSources: ALL_SOURCES,
+      sourceCommands: [],
+      searchScope: 'all'
+    };
   }
 
-  return { target: 'all', query: normalized, isEmpty: normalized.length === 0 };
+  const commandMatch = trimmed.match(/^\/(\S+)(?:\s+([\s\S]*))?$/);
+  const firstCommand = commandMatch?.[1]?.toLowerCase() ?? trimmed.slice(1).toLowerCase();
+  if (firstCommand in OPERATION_COMMANDS) {
+    const rawQuery = commandMatch?.[2] ?? '';
+    const target = OPERATION_COMMANDS[firstCommand];
+    const query = target === 'ask' ? rawQuery.trim() : '';
+    const isEmpty = target === 'clear' ? false : query.length === 0;
+
+    return {
+      target,
+      query,
+      isEmpty,
+      targetSources: [],
+      sourceCommands: [],
+      commandText: `/${firstCommand}`,
+      searchScope: 'operation'
+    };
+  }
+
+  const tokens = trimmed.split(/\s+/);
+  const commandNames: SearchCommandName[] = [];
+  const seenCommands = new Set<SearchCommandName>();
+  const queryTokens: string[] = [];
+
+  for (const token of tokens) {
+    if (queryTokens.length > 0) {
+      queryTokens.push(token);
+      continue;
+    }
+
+    if (!token.startsWith('/')) {
+      queryTokens.push(token);
+      continue;
+    }
+
+    const commandName = token.slice(1).toLowerCase() as SearchCommandName;
+    if (!(commandName in SEARCH_COMMAND_METADATA)) {
+      return buildFallbackQuery(normalized);
+    }
+
+    if (commandName === 'all') {
+      if (commandNames.length > 0) {
+        return buildFallbackQuery(normalized);
+      }
+    } else if (commandNames.includes('all')) {
+      return buildFallbackQuery(normalized);
+    }
+
+    if (!seenCommands.has(commandName)) {
+      seenCommands.add(commandName);
+      commandNames.push(commandName);
+    }
+  }
+
+  if (commandNames.length === 0) {
+    return buildFallbackQuery(normalized);
+  }
+
+  const query = normalizeQuery(queryTokens.join(' '));
+  const targetSources = expandSources(commandNames);
+  const firstMetadata = SEARCH_COMMAND_METADATA[commandNames[0]];
+  const target = commandNames.length === 1 ? firstMetadata.target : 'all';
+  const searchScope: SearchScope = commandNames.length === 1 && commandNames[0] === 'all' ? 'all' : 'scoped';
+
+  return {
+    target,
+    query,
+    isEmpty: query.length === 0,
+    targetSources,
+    sourceCommands: commandNames,
+    commandText: commandNames.map(command => `/${command}`).join(' '),
+    searchScope
+  };
 }
 
-export function getHelpText(command: string): string {
+function buildFallbackQuery(normalized: string): ParsedCommand {
+  return {
+    target: 'all',
+    query: normalized,
+    isEmpty: normalized.length === 0,
+    targetSources: ALL_SOURCES,
+    sourceCommands: [],
+    searchScope: 'all'
+  };
+}
+
+function expandSources(commandNames: readonly SearchCommandName[]): ContextSource[] {
+  const expanded: ContextSource[] = [];
+  const seenSources = new Set<ContextSource>();
+
+  for (const commandName of commandNames) {
+    for (const source of SEARCH_COMMAND_METADATA[commandName].sources) {
+      if (!seenSources.has(source)) {
+        seenSources.add(source);
+        expanded.push(source);
+      }
+    }
+  }
+
+  return expanded;
+}
+
+export function getHelpText(command: string | readonly SearchCommandName[]): string {
+  if (Array.isArray(command)) {
+    return getScopedHelpText(command);
+  }
+
+  const commandName = command as string;
+
   const examples: Record<string, string> = {
     mail: 'Example: /mail from:alice subject:budget\nExample: /mail incident review',
     teams: 'Example: /teams sprint review\nExample: /teams from:bob mentions:me',
@@ -69,9 +178,26 @@ export function getHelpText(command: string): string {
     onenote: 'Example: /onenote architecture decision log\nExample: /onenote section notebook architecture',
     planner: 'Example: /task release checklist\nExample: /task metadata comments onboarding',
     task: 'Example: /task release checklist\nExample: /task metadata comments onboarding',
-    all: 'Example: /all architecture decisions\nOr just type a query without a slash command.',
+    all: 'Example: /all architecture decisions\nExample: /mail /onedrive architecture decisions\nOr just type a query without a slash command.',
     ask: 'Example: /ask 日本語に翻訳してmarkdownにして\nExample: /ask Summarize the pinned docs as a bullet list\nPinned snippets are used as context and the Microsoft 365 Copilot response is opened in a new editor tab.',
     clear: 'Example: /clear\nClears the current chat transcript and discards all pinned snippets.'
   };
-  return examples[command] ?? 'Type a query to search Microsoft 365 content.';
+  return examples[commandName] ?? 'Type a query to search Microsoft 365 content.';
+}
+
+function getScopedHelpText(commands: readonly SearchCommandName[]): string {
+  if (commands.length === 0) {
+    return 'Type a query to search Microsoft 365 content.';
+  }
+
+  if (commands.length === 1) {
+    return getHelpText(commands[0]);
+  }
+
+  const prefix = commands.map(command => `/${command}`).join(' ');
+  return [
+    `Example: ${prefix} architecture decisions`,
+    `Example: ${prefix} incident review`,
+    'Searches only the explicitly requested sources.'
+  ].join('\n');
 }

--- a/src/router/commandRouter.ts
+++ b/src/router/commandRouter.ts
@@ -42,6 +42,10 @@ const OPERATION_COMMANDS: Record<string, RouteTarget> = {
   clear: 'clear'
 };
 
+function hasOwnKey<T extends object>(record: T, key: PropertyKey): key is keyof T {
+  return Object.prototype.hasOwnProperty.call(record, key);
+}
+
 function normalizeQuery(input: string): string {
   return input.replace(/\s+/g, ' ').trim();
 }
@@ -63,7 +67,7 @@ export function parseCommand(input: string): ParsedCommand {
 
   const commandMatch = trimmed.match(/^\/(\S+)(?:\s+([\s\S]*))?$/);
   const firstCommand = commandMatch?.[1]?.toLowerCase() ?? trimmed.slice(1).toLowerCase();
-  if (firstCommand in OPERATION_COMMANDS) {
+  if (hasOwnKey(OPERATION_COMMANDS, firstCommand)) {
     const rawQuery = commandMatch?.[2] ?? '';
     const target = OPERATION_COMMANDS[firstCommand];
     const query = target === 'ask' ? rawQuery.trim() : '';
@@ -96,10 +100,11 @@ export function parseCommand(input: string): ParsedCommand {
       continue;
     }
 
-    const commandName = token.slice(1).toLowerCase() as SearchCommandName;
-    if (!(commandName in SEARCH_COMMAND_METADATA)) {
+    const rawCommandName = token.slice(1).toLowerCase();
+    if (!hasOwnKey(SEARCH_COMMAND_METADATA, rawCommandName)) {
       return buildFallbackQuery(normalized);
     }
+    const commandName = rawCommandName;
 
     if (commandName === 'all') {
       if (commandNames.length > 0) {

--- a/src/test/suite/commandRouter.test.ts
+++ b/src/test/suite/commandRouter.test.ts
@@ -100,6 +100,20 @@ suite('CommandRouter', () => {
     assert.deepEqual(result.sourceCommands, []);
   });
 
+  test('prototype-like operation command falls back to a normal search query', () => {
+    const result = parseCommand('/__proto__ incident review');
+    assert.equal(result.target, 'all');
+    assert.equal(result.query, '/__proto__ incident review');
+    assert.deepEqual(result.sourceCommands, []);
+  });
+
+  test('prototype-like scoped command does not route through inherited metadata keys', () => {
+    const result = parseCommand('/mail /constructor incident review');
+    assert.equal(result.target, 'all');
+    assert.equal(result.query, '/mail /constructor incident review');
+    assert.deepEqual(result.sourceCommands, []);
+  });
+
   test('mixing /all with scoped commands falls back to /all query text', () => {
     const result = parseCommand('/all /mail architecture decisions');
     assert.equal(result.target, 'all');

--- a/src/test/suite/commandRouter.test.ts
+++ b/src/test/suite/commandRouter.test.ts
@@ -14,6 +14,8 @@ suite('CommandRouter', () => {
     assert.equal(result.target, 'mail');
     assert.equal(result.query, 'incident review');
     assert.equal(result.isEmpty, false);
+    assert.deepEqual(result.targetSources, ['mail']);
+    assert.deepEqual(result.sourceCommands, ['mail']);
   });
 
   test('/teams command routes to teams', () => {
@@ -44,6 +46,7 @@ suite('CommandRouter', () => {
     const result = parseCommand('/task release checklist');
     assert.equal(result.target, 'task');
     assert.equal(result.query, 'release checklist');
+    assert.deepEqual(result.targetSources, ['planner', 'todo']);
   });
 
   test('slash command accepts newline-separated query', () => {
@@ -64,6 +67,51 @@ suite('CommandRouter', () => {
     const result = parseCommand('/all architecture decisions');
     assert.equal(result.target, 'all');
     assert.equal(result.query, 'architecture decisions');
+    assert.equal(result.searchScope, 'all');
+  });
+
+  test('multiple slash commands route to only the requested sources', () => {
+    const result = parseCommand('/onedrive /mail quarterly plan');
+    assert.equal(result.target, 'all');
+    assert.equal(result.query, 'quarterly plan');
+    assert.equal(result.commandText, '/onedrive /mail');
+    assert.equal(result.searchScope, 'scoped');
+    assert.deepEqual(result.sourceCommands, ['onedrive', 'mail']);
+    assert.deepEqual(result.targetSources, ['onedrive', 'mail']);
+  });
+
+  test('deduplicates repeated slash commands', () => {
+    const result = parseCommand('/mail /mail incident review');
+    assert.equal(result.target, 'mail');
+    assert.deepEqual(result.sourceCommands, ['mail']);
+    assert.deepEqual(result.targetSources, ['mail']);
+  });
+
+  test('combines task search with another scoped command', () => {
+    const result = parseCommand('/mail /task release checklist');
+    assert.equal(result.target, 'all');
+    assert.deepEqual(result.targetSources, ['mail', 'planner', 'todo']);
+  });
+
+  test('mixed invalid scoped command falls back to /all query text', () => {
+    const result = parseCommand('/mail /unknown incident review');
+    assert.equal(result.target, 'all');
+    assert.equal(result.query, '/mail /unknown incident review');
+    assert.deepEqual(result.sourceCommands, []);
+  });
+
+  test('mixing /all with scoped commands falls back to /all query text', () => {
+    const result = parseCommand('/all /mail architecture decisions');
+    assert.equal(result.target, 'all');
+    assert.equal(result.query, '/all /mail architecture decisions');
+    assert.deepEqual(result.sourceCommands, []);
+  });
+
+  test('empty multi-command query stays empty and keeps the combined command text', () => {
+    const result = parseCommand('/mail /onedrive');
+    assert.equal(result.isEmpty, true);
+    assert.equal(result.commandText, '/mail /onedrive');
+    assert.deepEqual(result.targetSources, ['mail', 'onedrive']);
   });
 
   test('empty query after /mail sets isEmpty', () => {
@@ -105,6 +153,12 @@ suite('CommandRouter', () => {
   test('getHelpText returns onboarding examples for onenote and task search', () => {
     assert.ok(getHelpText('onenote').includes('/onenote'));
     assert.ok(getHelpText('task').includes('/task'));
+  });
+
+  test('getHelpText returns scoped multi-source examples', () => {
+    const text = getHelpText(['mail', 'onedrive']);
+    assert.ok(text.includes('/mail /onedrive'));
+    assert.ok(text.includes('explicitly requested sources'));
   });
 
   test('getHelpText returns fallback for unknown command', () => {

--- a/src/test/suite/searchSummary.test.ts
+++ b/src/test/suite/searchSummary.test.ts
@@ -23,9 +23,10 @@ suite('Search summary', () => {
         source: 'teams',
         items: [item('teams', 'Teams thread')]
       }
-    ]);
+    ], ['mail', 'teams']);
 
     assert.ok(summary.includes('Latest search query: `architecture review`'));
+    assert.ok(summary.includes('Requested sources: Mail, Teams'));
     assert.ok(summary.includes('Total results: 3'));
     assert.ok(summary.includes('Mail: 2 item(s) (cached). Top items: Mail one; Mail two.'));
     assert.ok(summary.includes('Teams: 1 item(s). Top items: Teams thread.'));

--- a/src/webview/chatRenderer.ts
+++ b/src/webview/chatRenderer.ts
@@ -309,7 +309,11 @@ export class ChatRenderer {
     const slashCode = document.createElement('code');
     slashCode.textContent = '/';
     commandsHint.appendChild(slashCode);
-    commandsHint.appendChild(document.createTextNode(' for available commands, or enter a keyword to search all sources.'));
+    commandsHint.appendChild(document.createTextNode(' for available commands, combine source commands like '));
+    const comboCode = document.createElement('code');
+    comboCode.textContent = '/mail /onedrive';
+    commandsHint.appendChild(comboCode);
+    commandsHint.appendChild(document.createTextNode(', or enter a keyword to search all sources.'));
     welcome.appendChild(commandsHint);
 
     const askHint = document.createElement('p');

--- a/src/webview/main.ts
+++ b/src/webview/main.ts
@@ -28,8 +28,8 @@ const slashMenuEl = document.getElementById('slashMenu')!;
 // --- Modules ---
 const renderer = new ChatRenderer(chatArea, vscode);
 
-const slashMenu = new SlashMenu(slashMenuEl, promptInput, (command: string) => {
-  promptInput.value = command + ' ';
+const slashMenu = new SlashMenu(slashMenuEl, promptInput, (nextValue: string) => {
+  promptInput.value = nextValue;
   promptInput.focus();
   slashMenu.hide();
 });

--- a/src/webview/slashMenu.ts
+++ b/src/webview/slashMenu.ts
@@ -30,12 +30,13 @@ export class SlashMenu {
   private input: HTMLTextAreaElement;
   private selectedIndex = -1;
   private filteredItems: SlashMenuItem[] = [];
-  private onSelect: (command: string) => void;
+  private onSelect: (nextValue: string) => void;
+  private selectionContext?: SlashSelectionContext;
 
   constructor(
     menuEl: HTMLElement,
     inputEl: HTMLTextAreaElement,
-    onSelect: (command: string) => void
+    onSelect: (nextValue: string) => void
   ) {
     this.menu = menuEl;
     this.input = inputEl;
@@ -49,18 +50,14 @@ export class SlashMenu {
    * Returns true if the menu is visible.
    */
   update(text: string): boolean {
-    const trimmed = text.trim();
-
-    // Show menu only when input starts with "/" and has no space (still typing command)
-    if (!trimmed.startsWith('/') || trimmed.includes(' ')) {
+    const context = this._getSelectionContext(text);
+    if (!context) {
       this.hide();
       return false;
     }
 
-    const partial = trimmed.toLowerCase();
-    this.filteredItems = SLASH_ITEMS.filter((item) =>
-      item.command.startsWith(partial)
-    );
+    this.selectionContext = context;
+    this.filteredItems = SLASH_ITEMS.filter(item => this._matchesContext(item, context));
 
     if (this.filteredItems.length === 0) {
       this.hide();
@@ -103,7 +100,7 @@ export class SlashMenu {
         if (this.selectedIndex >= 0 && this.selectedIndex < this.filteredItems.length) {
           e.preventDefault();
           const selected = this.filteredItems[this.selectedIndex];
-          this.onSelect(selected.command);
+          this._applySelection(selected.command);
           this.hide();
           return true;
         }
@@ -126,6 +123,7 @@ export class SlashMenu {
   hide(): void {
     this.menu.classList.remove('visible');
     this.selectedIndex = -1;
+    this.selectionContext = undefined;
     this.input.removeAttribute('aria-activedescendant');
   }
 
@@ -174,7 +172,7 @@ export class SlashMenu {
       el.addEventListener('click', () => {
         const cmd = el.dataset.command;
         if (cmd) {
-          this.onSelect(cmd);
+          this._applySelection(cmd);
           this.hide();
         }
       });
@@ -232,4 +230,70 @@ export class SlashMenu {
       this.input.removeAttribute('aria-activedescendant');
     }
   }
+
+  private _applySelection(command: string): void {
+    if (!this.selectionContext) {
+      this.onSelect(`${command} `);
+      return;
+    }
+
+    const nextValue = [...this.selectionContext.previousTokens, command].join(' ') + ' ';
+    this.onSelect(nextValue);
+  }
+
+  private _matchesContext(item: SlashMenuItem, context: SlashSelectionContext): boolean {
+    if (!item.command.startsWith(context.partial)) {
+      return false;
+    }
+
+    if (!context.combinableOnly) {
+      return true;
+    }
+
+    if (!COMBINABLE_COMMANDS.has(item.command)) {
+      return false;
+    }
+
+    return !context.selectedCommands.has(item.command);
+  }
+
+  private _getSelectionContext(text: string): SlashSelectionContext | undefined {
+    const trimmed = text.trim();
+    if (!trimmed.startsWith('/')) {
+      return undefined;
+    }
+
+    const hasTrailingWhitespace = /\s$/.test(text);
+    const tokens = trimmed.split(/\s+/);
+    const partial = hasTrailingWhitespace ? '/' : tokens[tokens.length - 1].toLowerCase();
+    const previousTokens = (hasTrailingWhitespace ? tokens : tokens.slice(0, -1)).map(token => token.toLowerCase());
+
+    if (!partial.startsWith('/')) {
+      return undefined;
+    }
+
+    const selectedCommands = new Set<string>();
+    for (const token of previousTokens) {
+      if (!COMBINABLE_COMMANDS.has(token)) {
+        return undefined;
+      }
+      selectedCommands.add(token);
+    }
+
+    return {
+      previousTokens,
+      partial,
+      selectedCommands,
+      combinableOnly: previousTokens.length > 0
+    };
+  }
 }
+
+interface SlashSelectionContext {
+  previousTokens: string[];
+  partial: string;
+  selectedCommands: Set<string>;
+  combinableOnly: boolean;
+}
+
+const COMBINABLE_COMMANDS = new Set(['/mail', '/teams', '/sharepoint', '/onedrive', '/onenote', '/task']);


### PR DESCRIPTION
## Summary
- support space-separated scoped slash commands such as `/onedrive /mail quarterly plan`
- keep `/ask` and `/clear` exclusive while falling back safely for ambiguous mixed slash input
- update slash-command help, webview input behavior, and search summaries to reflect scoped multi-source searches
- add regression coverage for multi-command parsing and scoped summaries

Closes #38
