### PR TITLE
Improve rich preview rendering for search results

### DIFF
--- a/media/panel.css
+++ b/media/panel.css
@@ -778,8 +778,6 @@ body {
 }
 
 .preview-body {
-  white-space: pre-wrap;
-  word-break: break-word;
   line-height: 1.55;
   font-size: 13px;
   color: var(--vscode-foreground);
@@ -787,6 +785,58 @@ body {
   border: 1px solid var(--cr-panel-border);
   border-radius: 16px;
   padding: var(--cr-spacing-lg);
+  overflow-x: auto;
+}
+
+.preview-body:not(.preview-body-html):not(.preview-body-image) {
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.preview-body-html :first-child {
+  margin-top: 0;
+}
+
+.preview-body-html :last-child {
+  margin-bottom: 0;
+}
+
+.preview-body-html table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.preview-body-html th,
+.preview-body-html td {
+  border: 1px solid var(--cr-panel-border);
+  padding: 6px 8px;
+  vertical-align: top;
+}
+
+.preview-body-html pre,
+.preview-body-html code {
+  font-family: var(--vscode-editor-font-family, monospace);
+}
+
+.preview-body-image {
+  display: flex;
+  flex-direction: column;
+  gap: var(--cr-spacing-md);
+}
+
+.preview-image {
+  width: 100%;
+  height: auto;
+  border-radius: 12px;
+  border: 1px solid var(--cr-panel-border);
+  background: var(--vscode-editor-background);
+}
+
+.preview-image-caption {
+  font-size: 12px;
+  color: var(--vscode-descriptionForeground);
+  white-space: pre-wrap;
+  word-break: break-word;
 }
 
 .preview-empty {

--- a/media/panel.js
+++ b/media/panel.js
@@ -601,7 +601,31 @@
 
     const body = document.createElement('div');
     body.className = 'preview-body';
-    body.textContent = preview.body || 'No preview text is available for this item yet.';
+
+    const previewText = getPreviewText(preview) || 'No preview text is available for this item yet.';
+    const contentKind = getPreviewContentKind(preview);
+    if (contentKind === 'html' && preview.content && typeof preview.content.html === 'string') {
+      body.classList.add('preview-body-html');
+      body.innerHTML = preview.content.html;
+    } else if (contentKind === 'image' && preview.content && typeof preview.content.src === 'string') {
+      body.classList.add('preview-body-image');
+
+      const image = document.createElement('img');
+      image.className = 'preview-image';
+      image.src = preview.content.src;
+      image.alt = preview.content.alt || `${preview.title || 'Preview'} image`;
+      body.appendChild(image);
+
+      if (previewText) {
+        const caption = document.createElement('div');
+        caption.className = 'preview-image-caption';
+        caption.textContent = previewText;
+        body.appendChild(caption);
+      }
+    } else {
+      body.textContent = previewText;
+    }
+
     previewContent.appendChild(body);
 
     if (preview.url) {
@@ -618,7 +642,11 @@
       previewContent.appendChild(actions);
     }
 
-    setPreviewSelectionStatus('本文を選択して Add selection、または Add preview で全文保存できます。');
+    if (contentKind === 'image') {
+      setPreviewSelectionStatus('Add preview で全文保存できます。画像プレビューでは本文選択はできません。');
+    } else {
+      setPreviewSelectionStatus('本文を選択して Add selection、または Add preview で全文保存できます。');
+    }
     updatePreviewActionState();
   }
 
@@ -855,7 +883,8 @@
   }
 
   function savePreviewToHandoff(selectionOnly) {
-    if (!currentPreviewItem || !currentPreview || !currentPreview.body) {
+    const previewBody = getPreviewText(currentPreview);
+    if (!currentPreviewItem || !currentPreview || !previewBody) {
       setPreviewSelectionStatus('保存できる preview がありません。先に検索結果を選択してください。');
       return;
     }
@@ -870,7 +899,7 @@
       type: 'savePreviewSnippet',
       item: currentPreviewItem,
       selectedText,
-      previewBody: currentPreview.body
+      previewBody
     });
   }
 
@@ -891,9 +920,10 @@
   }
 
   function updatePreviewActionState() {
-    const hasPreview = !!(currentPreviewItem && currentPreview && currentPreview.body);
+    const hasPreview = !!(currentPreviewItem && currentPreview && getPreviewText(currentPreview));
+    const hasSelectablePreview = hasPreview && getPreviewContentKind(currentPreview) !== 'image';
     if (previewSaveSelectionBtn) {
-      previewSaveSelectionBtn.disabled = !hasPreview;
+      previewSaveSelectionBtn.disabled = !hasSelectablePreview;
     }
     if (previewSavePreviewBtn) {
       previewSavePreviewBtn.disabled = !hasPreview;
@@ -904,7 +934,7 @@
   }
 
   function updatePreviewSelectionStatus() {
-    if (!currentPreview || !currentPreview.body) {
+    if (!currentPreview || !getPreviewText(currentPreview) || getPreviewContentKind(currentPreview) === 'image') {
       return;
     }
 
@@ -918,6 +948,18 @@
     if (previewSelectionStatus) {
       previewSelectionStatus.textContent = text;
     }
+  }
+
+  function getPreviewText(preview) {
+    return preview && preview.content && typeof preview.content.text === 'string'
+      ? preview.content.text.trim()
+      : '';
+  }
+
+  function getPreviewContentKind(preview) {
+    return preview && preview.content && typeof preview.content.kind === 'string'
+      ? preview.content.kind
+      : 'text';
   }
 
   function updateHandoffCount(count) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,14 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "jszip": "^3.10.1"
+        "jszip": "^3.10.1",
+        "marked": "^18.0.2",
+        "sanitize-html": "^2.17.3"
       },
       "devDependencies": {
         "@types/mocha": "^10.0.10",
         "@types/node": "^25.6.0",
+        "@types/sanitize-html": "^2.16.0",
         "@types/vscode": "^1.115.0",
         "@typescript-eslint/eslint-plugin": "^8.58.2",
         "@typescript-eslint/parser": "^8.58.2",
@@ -748,6 +751,49 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.19.0"
+      }
+    },
+    "node_modules/@types/sanitize-html": {
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/@types/sanitize-html/-/sanitize-html-2.16.0.tgz",
+      "integrity": "sha512-l6rX1MUXje5ztPT0cAFtUayXF06DqPhRyfVXareEN5gGCFaP/iwsxIyKODr9XDhfxPpN6vXUFNfo5kZMXCxBtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "htmlparser2": "^8.0.0"
+      }
+    },
+    "node_modules/@types/sanitize-html/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/@types/sanitize-html/node_modules/htmlparser2": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
+      "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1",
+        "entities": "^4.4.0"
       }
     },
     "node_modules/@types/vscode": {
@@ -1725,6 +1771,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/diff": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.2.tgz",
@@ -1733,6 +1788,73 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
+      }
+    },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/dom-serializer/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -1761,6 +1883,18 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/envinfo": {
@@ -1849,7 +1983,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -2312,6 +2445,25 @@
         "he": "bin/he"
       }
     },
+    "node_modules/htmlparser2": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
+      }
+    },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
@@ -2717,6 +2869,18 @@
         "node": "20 || >=22"
       }
     },
+    "node_modules/marked": {
+      "version": "18.0.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.2.tgz",
+      "integrity": "sha512-NsmlUYBS/Zg57rgDWMYdnre6OTj4e+qq/JS2ot3KrYLSoHLw+sDu0Nm1ZGpRgYAq6c+b1ekaY5NzVchMCQnzcg==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -2872,6 +3036,24 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -3063,6 +3245,12 @@
       "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
       "license": "(MIT AND Zlib)"
     },
+    "node_modules/parse-srcset": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
+      "integrity": "sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q==",
+      "license": "MIT"
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -3111,7 +3299,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -3194,6 +3381,34 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/prelude-ls": {
@@ -3362,6 +3577,29 @@
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "license": "MIT"
     },
+    "node_modules/sanitize-html": {
+      "version": "2.17.3",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.17.3.tgz",
+      "integrity": "sha512-Kn4srCAo2+wZyvCNKCSyB2g8RQ8IkX/gQs2uqoSRNu5t9I2qvUyAVvRDiFUVAiX3N3PNuwStY0eNr+ooBHVWEg==",
+      "license": "MIT",
+      "dependencies": {
+        "deepmerge": "^4.2.2",
+        "escape-string-regexp": "^4.0.0",
+        "htmlparser2": "^10.1.0",
+        "is-plain-object": "^5.0.0",
+        "parse-srcset": "^1.0.2",
+        "postcss": "^8.3.11"
+      }
+    },
+    "node_modules/sanitize-html/node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/schema-utils": {
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
@@ -3518,6 +3756,15 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">= 12"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/source-map-support": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "bugs": {
     "url": "https://github.com/kkamegawa/ContextRelay/issues"
-  },  
+  },
   "engines": {
     "node": ">=22.0.0",
     "vscode": "^1.85.0"
@@ -290,6 +290,7 @@
   "devDependencies": {
     "@types/mocha": "^10.0.10",
     "@types/node": "^25.6.0",
+    "@types/sanitize-html": "^2.16.0",
     "@types/vscode": "^1.115.0",
     "@typescript-eslint/eslint-plugin": "^8.58.2",
     "@typescript-eslint/parser": "^8.58.2",
@@ -304,6 +305,8 @@
     "webpack-cli": "^7.0.2"
   },
   "dependencies": {
-    "jszip": "^3.10.1"
+    "jszip": "^3.10.1",
+    "marked": "^18.0.2",
+    "sanitize-html": "^2.17.3"
   }
 }

--- a/src/adapters/handoffContentAdapter.ts
+++ b/src/adapters/handoffContentAdapter.ts
@@ -1,5 +1,5 @@
 import JSZip from 'jszip';
-import { ContextItem } from '../models/contextItem';
+import { ContextItem, getPreviewText } from '../models/contextItem';
 import { createMailPreview, getMailMessageId, normalizePreviewText } from '../panel/itemPreview';
 import { graphFetchWithRetry, handleGraphResponse, GRAPH_BASE } from './graphClient';
 
@@ -59,7 +59,7 @@ async function hydrateMailItem(token: string, item: ContextItem): Promise<Contex
   const response = await graphFetchWithRetry(url, token, { method: 'GET' });
   const data = await handleGraphResponse(response) as MailBodyResponse;
   const preview = createMailPreview(item, data);
-  return preview.body.trim() ? { ...item, snippet: preview.body } : item;
+  return getPreviewText(preview).trim() ? { ...item, snippet: getPreviewText(preview) } : item;
 }
 
 async function hydrateDriveItem(token: string, item: ContextItem): Promise<ContextItem> {

--- a/src/models/contextItem.ts
+++ b/src/models/contextItem.ts
@@ -23,10 +23,15 @@ export interface ContextItem {
   raw?: unknown;
 }
 
+export type PreviewContent =
+  | { kind: 'text'; text: string }
+  | { kind: 'html'; text: string; html: string }
+  | { kind: 'image'; text: string; src: string; alt?: string };
+
 export interface ResolvedPreview {
   source: ContextSource;
   title: string;
-  body: string;
+  content: PreviewContent;
   subtitle?: string;
   timestamp?: string;
   relevance?: number;
@@ -44,6 +49,10 @@ const INTERNAL_PREVIEW_SOURCES = new Set<ContextSource>(['planner', 'todo']);
 
 export function canOpenResult(item: Pick<ContextItem, 'source' | 'url'>): boolean {
   return Boolean(item.url?.trim()) || INTERNAL_PREVIEW_SOURCES.has(item.source);
+}
+
+export function getPreviewText(preview: Pick<ResolvedPreview, 'content'>): string {
+  return preview.content.text;
 }
 
 /**

--- a/src/panel/chatViewProvider.ts
+++ b/src/panel/chatViewProvider.ts
@@ -566,7 +566,7 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
       vscode.ViewColumn.Active,
       {
         enableScripts: false,
-        retainContextWhenHidden: true
+        retainContextWhenHidden: false
       }
     );
 

--- a/src/panel/chatViewProvider.ts
+++ b/src/panel/chatViewProvider.ts
@@ -1,7 +1,6 @@
 import * as crypto from 'crypto';
 import * as vscode from 'vscode';
 import { askCopilot } from '../adapters/chatAdapter';
-import { graphFetchWithRetry, handleGraphResponse, GRAPH_BASE } from '../adapters/graphClient';
 import { hydrateItemForHandoff } from '../adapters/handoffContentAdapter';
 import { searchMail } from '../adapters/mailAdapter';
 import { searchOneNote } from '../adapters/onenoteAdapter';
@@ -12,13 +11,13 @@ import { searchTodo } from '../adapters/todoAdapter';
 import { AuthProvider } from '../auth/authProvider';
 import { CacheStore } from '../cache/cacheStore';
 import { DocGenerator, type HandoffContext } from '../docs/docGenerator';
-import { type ContextItem, type ContextSource, getContextItemKey } from '../models/contextItem';
+import { type ContextItem, type ContextSource, type ResolvedPreview, getContextItemKey } from '../models/contextItem';
 import { getHelpText, parseCommand } from '../router/commandRouter';
 import { SnippetStore } from '../snippets/snippetStore';
 import { buildAskPrompt } from './askPrompt';
-import { createFallbackPreview, createMailPreview, getMailMessageId } from './itemPreview';
-import { buildPreviewDocument } from './openResult';
+import { buildPreviewWebviewHtml } from './openResult';
 import { detectOutputLanguage } from './outputLanguage';
+import { resolvePreview } from './previewResolver';
 import { buildSearchSummary, type SearchSummaryResult } from './searchSummary';
 import { type HostToWebviewMessage, type WebviewToHostMessage } from './types';
 import { CHAT_EDITOR_PANEL_ID, CHAT_VIEW_ID } from './chatViewConstants';
@@ -49,6 +48,7 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
   private static readonly MAX_TRANSCRIPT_LENGTH = 200;
   private transcript: HostToWebviewMessage[] = [];
   private editorPanel?: vscode.WebviewPanel;
+  private previewPanel?: vscode.WebviewPanel;
 
   constructor(
     private readonly context: vscode.ExtensionContext,
@@ -547,24 +547,40 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
       return;
     }
 
-    let preview = createFallbackPreview(item);
+    const preview = await resolvePreview(item, async () => this.authProvider.getAccessToken());
+    this.showPreviewPanel(preview);
+  }
 
-    if (item.source === 'mail') {
-      const token = await this.authProvider.getAccessToken();
-      const messageId = getMailMessageId(item);
-      if (messageId) {
-        const url = `${GRAPH_BASE}/v1.0/me/messages/${encodeURIComponent(messageId)}?$select=body`;
-        const response = await graphFetchWithRetry(url, token, { method: 'GET' });
-        const data = await handleGraphResponse(response) as { body?: { contentType?: string; content?: string } };
-        preview = createMailPreview(item, data);
-      }
+  private showPreviewPanel(preview: ResolvedPreview): void {
+    const existingPanel = this.previewPanel;
+    if (existingPanel) {
+      existingPanel.title = `ContextRelay Preview: ${preview.title}`;
+      existingPanel.webview.html = buildPreviewWebviewHtml(preview, existingPanel.webview.cspSource);
+      existingPanel.reveal(vscode.ViewColumn.Active);
+      return;
     }
 
-    const doc = await vscode.workspace.openTextDocument({
-      language: 'markdown',
-      content: buildPreviewDocument(preview)
-    });
-    await vscode.window.showTextDocument(doc, { preview: false });
+    const panel = vscode.window.createWebviewPanel(
+      'contextRelay.preview',
+      `ContextRelay Preview: ${preview.title}`,
+      vscode.ViewColumn.Active,
+      {
+        enableScripts: false,
+        retainContextWhenHidden: true
+      }
+    );
+
+    this.previewPanel = panel;
+    panel.webview.html = buildPreviewWebviewHtml(preview, panel.webview.cspSource);
+    panel.onDidDispose(
+      () => {
+        if (this.previewPanel === panel) {
+          this.previewPanel = undefined;
+        }
+      },
+      undefined,
+      this.context.subscriptions
+    );
   }
 
   private async fetchResults(

--- a/src/panel/itemPreview.ts
+++ b/src/panel/itemPreview.ts
@@ -1,4 +1,5 @@
-import { ContextItem, ResolvedPreview } from '../models/contextItem';
+import sanitizeHtml from 'sanitize-html';
+import { ContextItem, PreviewContent, ResolvedPreview } from '../models/contextItem';
 
 interface MailItemRaw {
   messageId?: string;
@@ -42,6 +43,25 @@ interface MailBodyResponse {
   };
 }
 
+const EMPTY_PREVIEW_TEXT = 'No preview text is available for this item yet.';
+const SANITIZE_ALLOWED_TAGS = Array.from(new Set([
+  ...sanitizeHtml.defaults.allowedTags,
+  'h1',
+  'h2',
+  'h3',
+  'h4',
+  'h5',
+  'h6',
+  'hr',
+  'table',
+  'thead',
+  'tbody',
+  'tfoot',
+  'tr',
+  'th',
+  'td'
+]));
+
 export function createFallbackPreview(item: ContextItem): ResolvedPreview {
   const body = getFallbackBody(item);
 
@@ -56,7 +76,7 @@ export function createFallbackPreview(item: ContextItem): ResolvedPreview {
         source: item.source,
         title: item.title,
         subtitle: senderText || undefined,
-        body,
+        content: createTextPreviewContent(body),
         timestamp: item.timestamp,
         url: item.url
       };
@@ -68,7 +88,7 @@ export function createFallbackPreview(item: ContextItem): ResolvedPreview {
         source: item.source,
         title: item.title,
         subtitle: subtitle || undefined,
-        body,
+        content: createTextPreviewContent(body),
         timestamp: item.timestamp,
         url: item.url
       };
@@ -80,7 +100,7 @@ export function createFallbackPreview(item: ContextItem): ResolvedPreview {
         source: item.source,
         title: item.title,
         subtitle: subtitle || undefined,
-        body,
+        content: createTextPreviewContent(body),
         timestamp: item.timestamp,
         url: item.url
       };
@@ -92,7 +112,7 @@ export function createFallbackPreview(item: ContextItem): ResolvedPreview {
         source: item.source,
         title: item.title,
         subtitle: subtitle || undefined,
-        body,
+        content: createTextPreviewContent(body),
         timestamp: item.timestamp,
         url: item.url
       };
@@ -104,7 +124,7 @@ export function createFallbackPreview(item: ContextItem): ResolvedPreview {
         source: item.source,
         title: item.title,
         subtitle: subtitle || undefined,
-        body,
+        content: createTextPreviewContent(body),
         timestamp: item.timestamp,
         url: item.url
       };
@@ -115,7 +135,7 @@ export function createFallbackPreview(item: ContextItem): ResolvedPreview {
       return {
         source: item.source,
         title: item.title,
-        body,
+        content: createTextPreviewContent(body),
         timestamp: item.timestamp,
         relevance: item.relevance,
         url: item.url
@@ -124,7 +144,7 @@ export function createFallbackPreview(item: ContextItem): ResolvedPreview {
       return {
         source: item.source,
         title: item.title,
-        body,
+        content: createTextPreviewContent(body),
         timestamp: item.timestamp,
         url: item.url
       };
@@ -134,20 +154,82 @@ export function createFallbackPreview(item: ContextItem): ResolvedPreview {
 export function createMailPreview(item: ContextItem, mailBody?: MailBodyResponse): ResolvedPreview {
   const fallback = createFallbackPreview(item);
   const raw = asMailItemRaw(item.raw);
-  const body = extractMailBody(mailBody) || fallback.body;
   const subtitle = [raw?.senderName, raw?.senderAddress ? `<${raw.senderAddress}>` : undefined]
     .filter(Boolean)
     .join(' ');
+  const body = mailBody?.body?.content ?? '';
+  const content = body
+    ? (mailBody?.body?.contentType === 'html'
+        ? createHtmlPreviewContent(body, fallback.content.text)
+        : createTextPreviewContent(body))
+    : fallback.content;
 
   return {
     ...fallback,
     subtitle: subtitle || fallback.subtitle,
-    body
+    content
   };
 }
 
 export function getMailMessageId(item: ContextItem): string | undefined {
   return asMailItemRaw(item.raw)?.messageId?.trim() || undefined;
+}
+
+export function createTextPreviewContent(value: string): PreviewContent {
+  const text = normalizePreviewText(value) || EMPTY_PREVIEW_TEXT;
+  return { kind: 'text', text };
+}
+
+export function createHtmlPreviewContent(value: string, fallbackText = ''): PreviewContent {
+  const html = sanitizePreviewHtml(value);
+  const text = normalizePreviewText(html, true) || normalizePreviewText(fallbackText) || EMPTY_PREVIEW_TEXT;
+
+  if (!html) {
+    return { kind: 'text', text };
+  }
+
+  return { kind: 'html', text, html };
+}
+
+export async function createMarkdownPreviewContent(value: string): Promise<PreviewContent> {
+  const markdown = normalizeDownloadedText(value);
+  if (!markdown) {
+    return createTextPreviewContent('');
+  }
+
+  const { marked } = await import('marked');
+  const rendered = marked.parse(markdown, { breaks: true, gfm: true });
+  return createHtmlPreviewContent(typeof rendered === 'string' ? rendered : String(rendered), markdown);
+}
+
+export function createStructuredTextPreviewContent(value: string): PreviewContent {
+  const text = normalizeDownloadedText(value);
+  if (!text) {
+    return createTextPreviewContent('');
+  }
+
+  return createHtmlPreviewContent(renderTextPreviewHtml(text), text);
+}
+
+export function createImagePreviewContent(src: string, options?: { text?: string; alt?: string }): PreviewContent {
+  return {
+    kind: 'image',
+    src,
+    alt: options?.alt,
+    text: normalizePreviewText(options?.text ?? '') || EMPTY_PREVIEW_TEXT
+  };
+}
+
+export function renderTextPreviewHtml(value: string): string {
+  const normalized = normalizeDownloadedText(value);
+  if (!normalized) {
+    return '';
+  }
+
+  return normalized
+    .split(/\n{2,}/)
+    .map(block => `<p>${escapeHtml(block).replace(/\n/g, '<br>')}</p>`)
+    .join('\n');
 }
 
 function getFallbackBody(item: ContextItem): string {
@@ -194,14 +276,6 @@ function getFallbackBody(item: ContextItem): string {
   return normalizePreviewText(item.snippet) || 'No preview text is available for this item yet.';
 }
 
-function extractMailBody(mailBody?: MailBodyResponse): string {
-  if (!mailBody?.body?.content) {
-    return '';
-  }
-
-  return normalizePreviewText(mailBody.body.content, mailBody.body.contentType === 'html');
-}
-
 export function normalizePreviewText(value: string, isHtml = false): string {
   if (!value?.trim()) {
     return '';
@@ -230,6 +304,41 @@ export function normalizePreviewText(value: string, isHtml = false): string {
     .trim();
 
   return normalized;
+}
+
+export function normalizeDownloadedText(value: string): string {
+  return value
+    .replace(/\uFEFF/g, '')
+    .replace(/\r\n/g, '\n')
+    .replace(/\r/g, '\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}
+
+export function sanitizePreviewHtml(value: string): string {
+  if (!value?.trim()) {
+    return '';
+  }
+
+  return sanitizeHtml(value, {
+    allowedTags: SANITIZE_ALLOWED_TAGS,
+    allowedAttributes: {
+      a: ['href', 'target', 'rel'],
+      td: ['colspan', 'rowspan'],
+      th: ['colspan', 'rowspan']
+    },
+    allowedSchemes: ['http', 'https', 'mailto'],
+    transformTags: {
+      a: (_tagName: string, attribs: Record<string, string>) => ({
+        tagName: 'a',
+        attribs: {
+          href: attribs.href,
+          target: '_blank',
+          rel: 'noreferrer noopener'
+        }
+      })
+    }
+  }).trim();
 }
 
 function decodeHtmlEntities(value: string): string {
@@ -266,4 +375,13 @@ function asTodoItemRaw(raw: unknown): TodoItemRaw | undefined {
 
 function asRetrievalItemRaw(raw: unknown): RetrievalItemRaw | undefined {
   return raw && typeof raw === 'object' ? raw as RetrievalItemRaw : undefined;
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
 }

--- a/src/panel/openResult.ts
+++ b/src/panel/openResult.ts
@@ -24,7 +24,7 @@ export function buildPreviewWebviewHtml(preview: ResolvedPreview, cspSource: str
     `<div class="meta-label">Source</div><div class="meta-value">${escapeHtml(getSourceLabel(preview.source))}</div>`,
     preview.subtitle ? `<div class="meta-label">Context</div><div class="meta-value">${escapeHtml(preview.subtitle)}</div>` : '',
     preview.timestamp ? `<div class="meta-label">Timestamp</div><div class="meta-value">${escapeHtml(preview.timestamp)}</div>` : '',
-    preview.url ? `<div class="meta-label">Link</div><div class="meta-value"><a href="${escapeAttribute(preview.url)}">${escapeHtml(preview.url)}</a></div>` : ''
+    preview.url ? `<div class="meta-label">Link</div><div class="meta-value">${buildPreviewLinkMarkup(preview.url)}</div>` : ''
   ].filter(Boolean);
 
   return `<!DOCTYPE html>
@@ -160,4 +160,27 @@ function escapeHtml(value: string): string {
 
 function escapeAttribute(value: string): string {
   return escapeHtml(value);
+}
+
+function buildPreviewLinkMarkup(url: string): string {
+  const safeUrl = getSafeExternalUrl(url);
+  if (!safeUrl) {
+    return escapeHtml(url);
+  }
+
+  const escaped = escapeAttribute(safeUrl);
+  return `<a href="${escaped}" target="_blank" rel="noreferrer noopener">${escapeHtml(safeUrl)}</a>`;
+}
+
+function getSafeExternalUrl(url: string): string | undefined {
+  try {
+    const parsed = new URL(url);
+    if (!['http:', 'https:', 'mailto:'].includes(parsed.protocol)) {
+      return undefined;
+    }
+
+    return parsed.toString();
+  } catch {
+    return undefined;
+  }
 }

--- a/src/panel/openResult.ts
+++ b/src/panel/openResult.ts
@@ -1,4 +1,4 @@
-import { ResolvedPreview } from '../models/contextItem';
+import { getPreviewText, ResolvedPreview } from '../models/contextItem';
 import { getSourceLabel } from '../sourcePresentation';
 export function buildPreviewDocument(preview: ResolvedPreview): string {
   const lines = [`# ${preview.title}`, ''];
@@ -15,6 +15,149 @@ export function buildPreviewDocument(preview: ResolvedPreview): string {
     lines.push('');
   }
 
-  lines.push(preview.body || 'No preview text is available for this item yet.');
+  lines.push(getPreviewText(preview) || 'No preview text is available for this item yet.');
   return lines.join('\n');
+}
+
+export function buildPreviewWebviewHtml(preview: ResolvedPreview, cspSource: string): string {
+  const metadata: string[] = [
+    `<div class="meta-label">Source</div><div class="meta-value">${escapeHtml(getSourceLabel(preview.source))}</div>`,
+    preview.subtitle ? `<div class="meta-label">Context</div><div class="meta-value">${escapeHtml(preview.subtitle)}</div>` : '',
+    preview.timestamp ? `<div class="meta-label">Timestamp</div><div class="meta-value">${escapeHtml(preview.timestamp)}</div>` : '',
+    preview.url ? `<div class="meta-label">Link</div><div class="meta-value"><a href="${escapeAttribute(preview.url)}">${escapeHtml(preview.url)}</a></div>` : ''
+  ].filter(Boolean);
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src ${cspSource} https: data:; style-src ${cspSource} 'unsafe-inline';">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>${escapeHtml(preview.title)}</title>
+  <style>
+    :root {
+      color-scheme: light dark;
+      font-family: var(--vscode-font-family, system-ui, sans-serif);
+    }
+    body {
+      margin: 0;
+      padding: 24px;
+      color: var(--vscode-editor-foreground);
+      background: var(--vscode-editor-background);
+      line-height: 1.6;
+    }
+    main {
+      max-width: 960px;
+      margin: 0 auto;
+      display: flex;
+      flex-direction: column;
+      gap: 20px;
+    }
+    h1 {
+      margin: 0;
+      font-size: 24px;
+      line-height: 1.3;
+      word-break: break-word;
+    }
+    .meta-grid {
+      display: grid;
+      grid-template-columns: max-content 1fr;
+      gap: 8px 12px;
+      padding: 16px;
+      border: 1px solid var(--vscode-panel-border);
+      border-radius: 12px;
+      background: color-mix(in srgb, var(--vscode-editor-background) 85%, var(--vscode-inputOption-activeBorder, #888) 15%);
+    }
+    .meta-label {
+      font-size: 12px;
+      color: var(--vscode-descriptionForeground);
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+    }
+    .meta-value {
+      word-break: break-word;
+    }
+    .preview-body {
+      padding: 20px;
+      border: 1px solid var(--vscode-panel-border);
+      border-radius: 16px;
+      background: color-mix(in srgb, var(--vscode-editor-background) 88%, var(--vscode-inputOption-activeBorder, #888) 12%);
+      overflow-x: auto;
+    }
+    .preview-body-text {
+      white-space: pre-wrap;
+      word-break: break-word;
+    }
+    .preview-body-html :first-child {
+      margin-top: 0;
+    }
+    .preview-body-html :last-child {
+      margin-bottom: 0;
+    }
+    .preview-body-html table {
+      width: 100%;
+      border-collapse: collapse;
+    }
+    .preview-body-html th,
+    .preview-body-html td {
+      border: 1px solid var(--vscode-panel-border);
+      padding: 6px 8px;
+      vertical-align: top;
+    }
+    .preview-body-image {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+      align-items: stretch;
+    }
+    .preview-body-image img {
+      width: 100%;
+      height: auto;
+      border-radius: 12px;
+      border: 1px solid var(--vscode-panel-border);
+      background: var(--vscode-editor-background);
+    }
+    .preview-image-caption {
+      font-size: 12px;
+      color: var(--vscode-descriptionForeground);
+      white-space: pre-wrap;
+      word-break: break-word;
+    }
+    a {
+      color: var(--vscode-textLink-foreground);
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>${escapeHtml(preview.title)}</h1>
+    ${metadata.length > 0 ? `<section class="meta-grid">${metadata.join('')}</section>` : ''}
+    ${buildPreviewBodyHtml(preview)}
+  </main>
+</body>
+</html>`;
+}
+
+function buildPreviewBodyHtml(preview: ResolvedPreview): string {
+  switch (preview.content.kind) {
+    case 'html':
+      return `<section class="preview-body preview-body-html">${preview.content.html}</section>`;
+    case 'image':
+      return `<section class="preview-body preview-body-image"><img src="${escapeAttribute(preview.content.src)}" alt="${escapeAttribute(preview.content.alt ?? preview.title)}">${getPreviewText(preview) ? `<div class="preview-image-caption">${escapeHtml(getPreviewText(preview))}</div>` : ''}</section>`;
+    default:
+      return `<section class="preview-body preview-body-text">${escapeHtml(getPreviewText(preview) || 'No preview text is available for this item yet.')}</section>`;
+  }
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function escapeAttribute(value: string): string {
+  return escapeHtml(value);
 }

--- a/src/panel/panelProvider.ts
+++ b/src/panel/panelProvider.ts
@@ -16,9 +16,8 @@ import { createConversation, sendMessage } from '../adapters/chatAdapter';
 import { ContextItem } from '../models/contextItem';
 import { hydrateItemForHandoff } from '../adapters/handoffContentAdapter';
 import { buildSearchSummary } from './searchSummary';
-import { createFallbackPreview, createMailPreview, getMailMessageId } from './itemPreview';
 import { buildHandoffSnippetDraft } from './handoffSelection';
-import { graphFetchWithRetry, handleGraphResponse, GRAPH_BASE } from '../adapters/graphClient';
+import { resolvePreview } from './previewResolver';
 
 interface SearchResult {
   source: string;
@@ -345,29 +344,7 @@ export class PanelProvider implements vscode.WebviewViewProvider {
     this.postMessage({ type: 'previewStart', item });
 
     try {
-      let preview = createFallbackPreview(item);
-
-      if (item.source === 'mail') {
-        let token: string;
-        try {
-          token = await this.authProvider.getAccessToken();
-        } catch (err) {
-          this.postMessage({
-            type: 'previewError',
-            message: err instanceof Error ? err.message : 'Authentication required for preview.'
-          });
-          return;
-        }
-
-        const messageId = getMailMessageId(item);
-        if (messageId) {
-          const url = `${GRAPH_BASE}/v1.0/me/messages/${encodeURIComponent(messageId)}?$select=body`;
-          const response = await graphFetchWithRetry(url, token, { method: 'GET' });
-          const data = await handleGraphResponse(response) as { body?: { contentType?: string; content?: string } };
-          preview = createMailPreview(item, data);
-        }
-      }
-
+      const preview = await resolvePreview(item, async () => this.authProvider.getAccessToken());
       this.postMessage({ type: 'previewContent', preview });
     } catch (err) {
       this.postMessage({

--- a/src/panel/previewResolver.ts
+++ b/src/panel/previewResolver.ts
@@ -1,0 +1,290 @@
+import JSZip from 'jszip';
+import { ContextItem, ResolvedPreview } from '../models/contextItem';
+import { graphFetchWithRetry, handleGraphResponse, GRAPH_BASE } from '../adapters/graphClient';
+import {
+  createFallbackPreview,
+  createImagePreviewContent,
+  createMailPreview,
+  createMarkdownPreviewContent,
+  createStructuredTextPreviewContent,
+  createTextPreviewContent,
+  getMailMessageId,
+  normalizeDownloadedText,
+  normalizePreviewText
+} from './itemPreview';
+
+interface MailBodyResponse {
+  body?: {
+    contentType?: string;
+    content?: string;
+  };
+}
+
+interface DriveItemRaw {
+  id?: string;
+  driveId?: string;
+  siteId?: string;
+  path?: string;
+  mimeType?: string;
+  extracts?: string[];
+}
+
+type DrivePreviewMode =
+  | 'plainText'
+  | 'markdown'
+  | 'html'
+  | 'docx'
+  | 'htmlConvertible'
+  | 'imageConvertible'
+  | 'unsupported';
+
+const TEXT_EXTENSIONS = new Set([
+  'txt', 'json', 'jsonl', 'csv', 'tsv', 'log', 'xml', 'yaml', 'yml',
+  'css', 'js', 'ts', 'tsx', 'jsx', 'py', 'java', 'cs', 'go', 'rs', 'sql'
+]);
+const MARKDOWN_EXTENSIONS = new Set(['md', 'markdown']);
+const HTML_EXTENSIONS = new Set(['html', 'htm']);
+const HTML_CONVERTIBLE_EXTENSIONS = new Set(['eml', 'msg']);
+const DOCX_EXTENSIONS = new Set(['docx', 'dotx', 'docm', 'dotm']);
+const IMAGE_PREVIEW_EXTENSIONS = new Set(['ppt', 'pptx', 'pptm', 'pps', 'ppsx', 'xls', 'xlsx', 'xlsm']);
+
+export async function resolvePreview(
+  item: ContextItem,
+  getAccessToken: () => Promise<string>
+): Promise<ResolvedPreview> {
+  const fallback = createFallbackPreview(item);
+
+  switch (item.source) {
+    case 'mail':
+      return resolveMailPreview(item, fallback, getAccessToken);
+    case 'sharepoint':
+    case 'onedrive':
+      return resolveDrivePreview(item, fallback, getAccessToken);
+    default:
+      return fallback;
+  }
+}
+
+export function inferDrivePreviewMode(name: string, mimeType?: string): DrivePreviewMode {
+  const extension = getExtension(name);
+
+  if (DOCX_EXTENSIONS.has(extension)) {
+    return 'docx';
+  }
+
+  if (MARKDOWN_EXTENSIONS.has(extension)) {
+    return 'markdown';
+  }
+
+  if (HTML_EXTENSIONS.has(extension)) {
+    return 'html';
+  }
+
+  if (HTML_CONVERTIBLE_EXTENSIONS.has(extension)) {
+    return 'htmlConvertible';
+  }
+
+  if (IMAGE_PREVIEW_EXTENSIONS.has(extension)) {
+    return 'imageConvertible';
+  }
+
+  if (TEXT_EXTENSIONS.has(extension)) {
+    return 'plainText';
+  }
+
+  if (mimeType?.startsWith('text/')) {
+    return mimeType.includes('markdown') ? 'markdown' : 'plainText';
+  }
+
+  if (mimeType === 'application/json' || mimeType === 'application/xml') {
+    return 'plainText';
+  }
+
+  return 'unsupported';
+}
+
+async function resolveMailPreview(
+  item: ContextItem,
+  fallback: ResolvedPreview,
+  getAccessToken: () => Promise<string>
+): Promise<ResolvedPreview> {
+  const messageId = getMailMessageId(item);
+  if (!messageId) {
+    return fallback;
+  }
+
+  try {
+    const token = await getAccessToken();
+    const url = `${GRAPH_BASE}/v1.0/me/messages/${encodeURIComponent(messageId)}?$select=body`;
+    const response = await graphFetchWithRetry(url, token, { method: 'GET' });
+    const data = await handleGraphResponse(response) as MailBodyResponse;
+    return createMailPreview(item, data);
+  } catch {
+    return fallback;
+  }
+}
+
+async function resolveDrivePreview(
+  item: ContextItem,
+  fallback: ResolvedPreview,
+  getAccessToken: () => Promise<string>
+): Promise<ResolvedPreview> {
+  const raw = asDriveItemRaw(item.raw);
+  if (!raw?.driveId || !raw.id) {
+    return fallback;
+  }
+
+  const mode = inferDrivePreviewMode(item.title, raw.mimeType);
+  if (mode === 'unsupported') {
+    return fallback;
+  }
+
+  try {
+    const token = await getAccessToken();
+
+    switch (mode) {
+      case 'plainText': {
+        const response = await fetchDriveItemResponse(token, raw.driveId, raw.id);
+        const text = normalizeDownloadedText(await response.text());
+        return text ? { ...fallback, content: createTextPreviewContent(text) } : fallback;
+      }
+      case 'markdown': {
+        const response = await fetchDriveItemResponse(token, raw.driveId, raw.id);
+        const text = normalizeDownloadedText(await response.text());
+        return text ? { ...fallback, content: await createMarkdownPreviewContent(text) } : fallback;
+      }
+      case 'html': {
+        const response = await fetchDriveItemResponse(token, raw.driveId, raw.id);
+        const html = await response.text();
+        return html ? { ...fallback, content: createStructuredTextPreviewContent(normalizePreviewText(html, true)) } : fallback;
+      }
+      case 'htmlConvertible': {
+        const response = await fetchDriveItemResponse(token, raw.driveId, raw.id, { format: 'html' });
+        const html = await response.text();
+        return html ? { ...fallback, content: createMailLikeHtmlPreview(html, fallback.content.text) } : fallback;
+      }
+      case 'docx': {
+        const response = await fetchDriveItemResponse(token, raw.driveId, raw.id);
+        const bytes = new Uint8Array(await response.arrayBuffer());
+        const docxPreview = await extractDocxPreview(bytes);
+        return docxPreview.text ? { ...fallback, content: createStructuredTextPreviewContent(docxPreview.text) } : fallback;
+      }
+      case 'imageConvertible': {
+        const response = await fetchDriveItemResponse(token, raw.driveId, raw.id, {
+          format: 'jpg',
+          width: 1600,
+          height: 1200
+        });
+        const bytes = new Uint8Array(await response.arrayBuffer());
+        if (bytes.byteLength === 0) {
+          return fallback;
+        }
+
+        return {
+          ...fallback,
+          content: createImagePreviewContent(`data:image/jpeg;base64,${Buffer.from(bytes).toString('base64')}`, {
+            text: fallback.content.text,
+            alt: `${item.title} preview image`
+          })
+        };
+      }
+      default:
+        return fallback;
+    }
+  } catch {
+    return fallback;
+  }
+}
+
+async function fetchDriveItemResponse(
+  token: string,
+  driveId: string,
+  itemId: string,
+  options?: { format?: 'html' | 'jpg'; width?: number; height?: number }
+): Promise<Response> {
+  const query = new URLSearchParams();
+  if (options?.format) {
+    query.set('format', options.format);
+  }
+  if (typeof options?.width === 'number') {
+    query.set('width', String(options.width));
+  }
+  if (typeof options?.height === 'number') {
+    query.set('height', String(options.height));
+  }
+
+  const suffix = query.size > 0 ? `?${query.toString()}` : '';
+  const url = `${GRAPH_BASE}/v1.0/drives/${encodeURIComponent(driveId)}/items/${encodeURIComponent(itemId)}/content${suffix}`;
+  const response = await graphFetchWithRetry(url, token, { method: 'GET' });
+  if (!response.ok) {
+    await handleGraphResponse(response);
+  }
+
+  return response;
+}
+
+async function extractDocxPreview(bytes: Uint8Array): Promise<{ text: string }> {
+  const zip = await JSZip.loadAsync(bytes);
+  const entries = zip.file(/^word\/(document|header\d+|footer\d+|footnotes|endnotes)\.xml$/i);
+  const parts: string[] = [];
+
+  for (const entry of entries) {
+    const xml = await entry.async('text');
+    const text = extractWordprocessingText(xml);
+    if (text) {
+      parts.push(text);
+    }
+  }
+
+  return { text: parts.join('\n\n').trim() };
+}
+
+function extractWordprocessingText(xml: string): string {
+  return decodeXmlEntities(
+    xml
+      .replace(/<w:tab\s*\/?>/gi, '\t')
+      .replace(/<w:(?:br|cr)\s*\/?>/gi, '\n')
+      .replace(/<\/w:p>/gi, '\n\n')
+      .replace(/<[^>]+>/g, '')
+  )
+    .replace(/\r\n/g, '\n')
+    .replace(/[ \t]+\n/g, '\n')
+    .replace(/\n[ \t]+/g, '\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .replace(/[ \t]{2,}/g, ' ')
+    .trim();
+}
+
+function decodeXmlEntities(value: string): string {
+  return value
+    .replace(/&nbsp;/gi, ' ')
+    .replace(/&amp;/gi, '&')
+    .replace(/&lt;/gi, '<')
+    .replace(/&gt;/gi, '>')
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;/gi, "'")
+    .replace(/&#x([0-9a-f]+);/gi, (_, hex: string) => String.fromCodePoint(parseInt(hex, 16)))
+    .replace(/&#(\d+);/g, (_, decimal: string) => String.fromCodePoint(parseInt(decimal, 10)));
+}
+
+function getExtension(name: string): string {
+  const index = name.lastIndexOf('.');
+  return index === -1 ? '' : name.slice(index + 1).toLowerCase();
+}
+
+function asDriveItemRaw(raw: unknown): DriveItemRaw | undefined {
+  return raw && typeof raw === 'object' ? raw as DriveItemRaw : undefined;
+}
+
+function createMailLikeHtmlPreview(html: string, fallbackText: string): ResolvedPreview['content'] {
+  const preview = createMailPreview(
+    {
+      source: 'mail',
+      title: 'Mail',
+      snippet: fallbackText,
+      cache: { hit: false }
+    },
+    { body: { contentType: 'html', content: html } }
+  );
+  return preview.content;
+}

--- a/src/test/suite/dependencyVersions.test.ts
+++ b/src/test/suite/dependencyVersions.test.ts
@@ -3,6 +3,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 
 interface PackageJson {
+  dependencies?: Record<string, string>;
   devDependencies?: Record<string, string>;
   engines?: Record<string, string>;
   scripts?: Record<string, string>;
@@ -146,6 +147,31 @@ suite('Dependency security baselines', () => {
       Boolean(diffVersion) &&
         (compareVersions(diffVersion, '6.0.0') < 0 || compareVersions(diffVersion, '8.0.3') >= 0),
       `installed diff must stay outside the vulnerable range 6.0.0-8.0.2 (found: ${diffVersion ?? 'missing'})`
+    );
+  });
+
+  test('pins preview rendering dependencies at vetted versions', () => {
+    const packageJson = readRepoJson<PackageJson>('package.json');
+    const packageLockJson = readRepoJson<PackageLockJson>('package-lock.json');
+
+    assert.ok(
+      compareVersions(packageJson.dependencies?.marked, '18.0.2') >= 0,
+      `marked must stay on a vetted baseline or newer (found: ${packageJson.dependencies?.marked ?? 'missing'})`
+    );
+    assert.ok(
+      compareVersions(packageJson.dependencies?.['sanitize-html'], '2.17.3') >= 0,
+      `sanitize-html must stay on a vetted baseline or newer (found: ${packageJson.dependencies?.['sanitize-html'] ?? 'missing'})`
+    );
+
+    assert.equal(
+      packageLockJson.packages?.['node_modules/marked']?.deprecated,
+      undefined,
+      `installed marked must not be deprecated (found: ${packageLockJson.packages?.['node_modules/marked']?.deprecated ?? 'not deprecated'})`
+    );
+    assert.equal(
+      packageLockJson.packages?.['node_modules/sanitize-html']?.deprecated,
+      undefined,
+      `installed sanitize-html must not be deprecated (found: ${packageLockJson.packages?.['node_modules/sanitize-html']?.deprecated ?? 'not deprecated'})`
     );
   });
 });

--- a/src/test/suite/itemPreview.test.ts
+++ b/src/test/suite/itemPreview.test.ts
@@ -1,6 +1,7 @@
 import { strict as assert } from 'assert';
-import { ContextItem } from '../../models/contextItem';
+import { ContextItem, getPreviewText } from '../../models/contextItem';
 import {
+  createMarkdownPreviewContent,
   createFallbackPreview,
   createMailPreview,
   getMailMessageId,
@@ -31,7 +32,7 @@ suite('Item preview', () => {
     }));
 
     assert.equal(preview.source, 'sharepoint');
-    assert.equal(preview.body, 'First paragraph\n\nSecond paragraph');
+    assert.equal(getPreviewText(preview), 'First paragraph\n\nSecond paragraph');
   });
 
   test('creates full mail preview from fetched body', () => {
@@ -52,7 +53,8 @@ suite('Item preview', () => {
     });
 
     assert.equal(preview.subtitle, 'Adele Vance <adele@example.com>');
-    assert.equal(preview.body, 'Hello team,\n\nThis is the full message.');
+    assert.equal(preview.content.kind, 'html');
+    assert.equal(getPreviewText(preview), 'Hello team,\n\nThis is the full message.');
     assert.equal(getMailMessageId(item), 'abc123');
   });
 
@@ -60,7 +62,7 @@ suite('Item preview', () => {
     const item = makeItem({ source: 'teams', snippet: 'Short summary from Teams' });
     const preview = createFallbackPreview(item);
 
-    assert.equal(preview.body, 'Short summary from Teams');
+    assert.equal(getPreviewText(preview), 'Short summary from Teams');
   });
 
   test('includes OneNote hierarchy in preview subtitle when available', () => {
@@ -75,7 +77,7 @@ suite('Item preview', () => {
     }));
 
     assert.equal(preview.subtitle, 'Architecture · Engineering wiki');
-    assert.equal(preview.body, 'Page preview');
+    assert.equal(getPreviewText(preview), 'Page preview');
   });
 
   test('includes Planner metadata in preview subtitle when available', () => {
@@ -90,7 +92,7 @@ suite('Item preview', () => {
     }));
 
     assert.equal(preview.subtitle, 'Release train · Ready');
-    assert.equal(preview.body, 'Task description');
+    assert.equal(getPreviewText(preview), 'Task description');
   });
 
   test('includes To Do metadata in preview subtitle when available', () => {
@@ -105,6 +107,14 @@ suite('Item preview', () => {
     }));
 
     assert.equal(preview.subtitle, 'Personal · notStarted');
-    assert.equal(preview.body, 'Need milk and fruit');
+    assert.equal(getPreviewText(preview), 'Need milk and fruit');
+  });
+
+  test('renders markdown preview content as sanitized html', async () => {
+    const preview = await createMarkdownPreviewContent('# Title\n\n- First\n- Second');
+
+    assert.equal(preview.kind, 'html');
+    assert.ok(preview.html.includes('<h1>Title</h1>'));
+    assert.equal(preview.text, 'Title\n\n• First\n\n• Second');
   });
 });

--- a/src/test/suite/openResult.test.ts
+++ b/src/test/suite/openResult.test.ts
@@ -44,4 +44,25 @@ suite('Open result', () => {
     assert.ok(html.includes('data:image/jpeg;base64,abc123'));
     assert.ok(html.includes('Executive summary'));
   });
+
+  test('renders only safe metadata links as clickable anchors', () => {
+    const safeHtml = buildPreviewWebviewHtml({
+      source: 'mail',
+      title: 'Safe link',
+      url: 'https://example.com/path?q=1',
+      content: { kind: 'text', text: 'Body' }
+    }, 'vscode-resource:preview');
+    const unsafeHtml = buildPreviewWebviewHtml({
+      source: 'mail',
+      title: 'Unsafe link',
+      url: 'javascript:alert(1)',
+      content: { kind: 'text', text: 'Body' }
+    }, 'vscode-resource:preview');
+
+    assert.ok(safeHtml.includes('target="_blank"'));
+    assert.ok(safeHtml.includes('rel="noreferrer noopener"'));
+    assert.ok(safeHtml.includes('<a href="https://example.com/path?q=1"'));
+    assert.ok(unsafeHtml.includes('javascript:alert(1)'));
+    assert.ok(!unsafeHtml.includes('<a href="javascript:alert(1)"'));
+  });
 });

--- a/src/test/suite/openResult.test.ts
+++ b/src/test/suite/openResult.test.ts
@@ -1,5 +1,5 @@
 import { strict as assert } from 'assert';
-import { buildPreviewDocument } from '../../panel/openResult';
+import { buildPreviewDocument, buildPreviewWebviewHtml } from '../../panel/openResult';
 import { canOpenResult } from '../../models/contextItem';
 
 suite('Open result', () => {
@@ -18,7 +18,7 @@ suite('Open result', () => {
       source: 'todo',
       title: 'Buy groceries',
       subtitle: 'Personal · notStarted',
-      body: 'Need milk and fruit',
+      content: { kind: 'text', text: 'Need milk and fruit' },
       timestamp: '2026-04-30T00:00:00Z'
     });
 
@@ -26,5 +26,22 @@ suite('Open result', () => {
     assert.ok(content.includes('- Source: Microsoft To Do'));
     assert.ok(content.includes('- Context: Personal · notStarted'));
     assert.ok(content.includes('Need milk and fruit'));
+  });
+
+  test('builds rich preview webview html for image previews', () => {
+    const html = buildPreviewWebviewHtml({
+      source: 'sharepoint',
+      title: 'Quarterly deck',
+      content: {
+        kind: 'image',
+        src: 'data:image/jpeg;base64,abc123',
+        alt: 'Quarterly deck preview image',
+        text: 'Executive summary'
+      }
+    }, 'vscode-resource:preview');
+
+    assert.ok(html.includes('Quarterly deck'));
+    assert.ok(html.includes('data:image/jpeg;base64,abc123'));
+    assert.ok(html.includes('Executive summary'));
   });
 });

--- a/src/test/suite/previewResolver.test.ts
+++ b/src/test/suite/previewResolver.test.ts
@@ -1,0 +1,77 @@
+import { strict as assert } from 'assert';
+import { ContextItem, getPreviewText } from '../../models/contextItem';
+import { inferDrivePreviewMode, resolvePreview } from '../../panel/previewResolver';
+
+function makeDriveItem(overrides: Partial<ContextItem> = {}): ContextItem {
+  return {
+    source: 'sharepoint',
+    title: 'notes.md',
+    snippet: 'Fallback snippet',
+    cache: { hit: false },
+    raw: {
+      driveId: 'drive-1',
+      id: 'item-1',
+      mimeType: 'text/markdown',
+      extracts: ['Fallback snippet']
+    },
+    ...overrides
+  };
+}
+
+suite('Preview resolver', () => {
+  test('detects markdown and image-convertible drive previews', () => {
+    assert.equal(inferDrivePreviewMode('notes.md', 'text/markdown'), 'markdown');
+    assert.equal(
+      inferDrivePreviewMode(
+        'deck.pptx',
+        'application/vnd.openxmlformats-officedocument.presentationml.presentation'
+      ),
+      'imageConvertible'
+    );
+  });
+
+  test('renders markdown drive items as html previews', async () => {
+    const originalFetch = globalThis.fetch;
+
+    globalThis.fetch = (async () => new Response('# Title\n\n- First\n- Second', {
+      status: 200,
+      headers: { 'Content-Type': 'text/markdown' }
+    })) as typeof fetch;
+
+    try {
+      const preview = await resolvePreview(makeDriveItem(), async () => 'token');
+
+      assert.equal(preview.content.kind, 'html');
+      assert.ok(preview.content.html.includes('<h1>Title</h1>'));
+      assert.equal(getPreviewText(preview), 'Title\n\n• First\n\n• Second');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test('falls back to plain text preview when image conversion fails', async () => {
+    const originalFetch = globalThis.fetch;
+
+    globalThis.fetch = (async () => new Response('conversion failed', {
+      status: 500,
+      headers: { 'Content-Type': 'text/plain' }
+    })) as typeof fetch;
+
+    try {
+      const preview = await resolvePreview(makeDriveItem({
+        title: 'deck.pptx',
+        raw: {
+          driveId: 'drive-1',
+          id: 'item-1',
+          mimeType: 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+          extracts: ['Slide summary']
+        }
+      }), async () => 'token');
+
+      assert.equal(preview.content.kind, 'text');
+      assert.equal(getPreviewText(preview), 'Slide summary');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add a richer preview model that supports text, sanitized HTML, and image previews
- render markdown/docx/mail content in readable HTML, and render pptx/xlsx as image-first previews with text fallback
- align the ChatView open flow with the same rich preview rendering path and add regression coverage for the new dependencies and preview resolver

## Validation
- npm run compile
- npm run lint
- npm test
- npm run security:check

Closes #42