### PR TITLE
Improve retrieval snippet fallback

### DIFF
--- a/src/adapters/retrievalSearchUtils.ts
+++ b/src/adapters/retrievalSearchUtils.ts
@@ -25,8 +25,9 @@ export function buildSearchSnippet(summary?: string, description?: string, webUr
     return normalizedSummary;
   }
 
-  if (description?.trim()) {
-    return description.trim();
+  const normalizedDescription = description?.trim() ?? '';
+  if (normalizedDescription && !looksLikeRawLocation(normalizedDescription)) {
+    return normalizedDescription;
   }
 
   return formatLocationSnippet(undefined, webUrl);
@@ -43,9 +44,22 @@ export function formatLocationSnippet(path?: string, webUrl?: string): string {
 
   try {
     const parsed = new URL(webUrl);
-    return `${parsed.hostname}${parsed.pathname}`;
+    const segments = parsed.pathname
+      .split('/')
+      .filter(Boolean)
+      .map(segment => safeDecodeURIComponent(segment))
+      .map(segment => segment.trim())
+      .filter(Boolean);
+
+    const filteredSegments = trimStorageBoilerplate(segments).filter(segment => segment.toLowerCase() !== 'preview');
+    const tail = filteredSegments.slice(-3);
+    if (tail.length > 0) {
+      return tail.join(' / ');
+    }
+
+    return 'Location available';
   } catch {
-    return webUrl;
+    return 'Location available';
   }
 }
 
@@ -56,5 +70,43 @@ export function getTitleFromUrl(webUrl: string): string | undefined {
     return segments[segments.length - 1];
   } catch {
     return undefined;
+  }
+}
+
+function looksLikeRawLocation(value: string): boolean {
+  return /^https?:\/\//i.test(value) || /(?:^|[\s/])[\w-]+(?:-my)?\.sharepoint\.com\//i.test(value);
+}
+
+function trimStorageBoilerplate(segments: string[]): string[] {
+  const documentIndex = findLastMatchingIndex(
+    segments,
+    segment => normalizeSegment(segment) === 'documents' || normalizeSegment(segment) === 'shared documents'
+  );
+  if (documentIndex !== -1 && documentIndex < segments.length - 1) {
+    return segments.slice(documentIndex + 1);
+  }
+
+  return segments;
+}
+
+function findLastMatchingIndex(values: string[], predicate: (value: string) => boolean): number {
+  for (let index = values.length - 1; index >= 0; index -= 1) {
+    if (predicate(values[index])) {
+      return index;
+    }
+  }
+
+  return -1;
+}
+
+function normalizeSegment(value: string): string {
+  return value.replace(/\+/g, ' ').trim().toLowerCase();
+}
+
+function safeDecodeURIComponent(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
   }
 }

--- a/src/test/suite/retrievalAdapter.test.ts
+++ b/src/test/suite/retrievalAdapter.test.ts
@@ -1,6 +1,6 @@
 import { strict as assert } from 'assert';
 import Module from 'module';
-import { buildSearchSnippet, escapeODataString, isOneDriveUrl, stripSearchMarkup } from '../../adapters/retrievalSearchUtils';
+import { buildSearchSnippet, escapeODataString, formatLocationSnippet, isOneDriveUrl, stripSearchMarkup } from '../../adapters/retrievalSearchUtils';
 
 type SearchRetrievalFn = typeof import('../../adapters/retrievalAdapter').searchRetrieval;
 type ModuleLoader = typeof Module & {
@@ -57,6 +57,27 @@ suite('Retrieval adapter', () => {
     assert.equal(
       buildSearchSnippet('<c0>Architecture</c0> review <ddd/> excerpt', undefined, 'https://contoso-my.sharepoint.com/personal/user/Documents/file.docx'),
       'Architecture review … excerpt'
+    );
+  });
+
+  test('formats raw OneDrive URLs as concise location snippets', () => {
+    assert.equal(
+      formatLocationSnippet(
+        undefined,
+        'https://contoso-my.sharepoint.com/personal/user_contoso_com/Documents/%E8%B3%87%E6%96%99/MVP/GitHub'
+      ),
+      '資料 / MVP / GitHub'
+    );
+  });
+
+  test('does not use raw SharePoint location strings as snippets', () => {
+    assert.equal(
+      buildSearchSnippet(
+        undefined,
+        'contoso-my.sharepoint.com/personal/user_contoso_com/Documents/%E8%B3%87%E6%96%99/MVP/GitHub',
+        'https://contoso-my.sharepoint.com/personal/user_contoso_com/Documents/%E8%B3%87%E6%96%99/MVP/GitHub'
+      ),
+      '資料 / MVP / GitHub'
     );
   });
 

--- a/src/test/suite/retrievalAdapter.test.ts
+++ b/src/test/suite/retrievalAdapter.test.ts
@@ -64,20 +64,31 @@ suite('Retrieval adapter', () => {
     assert.equal(
       formatLocationSnippet(
         undefined,
-        'https://contoso-my.sharepoint.com/personal/user_contoso_com/Documents/%E8%B3%87%E6%96%99/MVP/GitHub'
+        'https://contoso-my.sharepoint.com/personal/user_contoso_com/Documents/%E8%B3%87%E6%96%99/Reference/Notes'
       ),
-      '資料 / MVP / GitHub'
+      '資料 / Reference / Notes'
     );
   });
 
-  test('does not use raw SharePoint location strings as snippets', () => {
+  test('does not use raw OneDrive personal location strings as snippets', () => {
     assert.equal(
       buildSearchSnippet(
         undefined,
-        'contoso-my.sharepoint.com/personal/user_contoso_com/Documents/%E8%B3%87%E6%96%99/MVP/GitHub',
-        'https://contoso-my.sharepoint.com/personal/user_contoso_com/Documents/%E8%B3%87%E6%96%99/MVP/GitHub'
+        'contoso-my.sharepoint.com/personal/user_contoso_com/Documents/%E8%B3%87%E6%96%99/Reference/Notes',
+        'https://contoso-my.sharepoint.com/personal/user_contoso_com/Documents/%E8%B3%87%E6%96%99/Reference/Notes'
       ),
-      '資料 / MVP / GitHub'
+      '資料 / Reference / Notes'
+    );
+  });
+
+  test('does not use raw SharePoint site location strings as snippets', () => {
+    assert.equal(
+      buildSearchSnippet(
+        undefined,
+        'contoso.sharepoint.com/sites/engineering/Shared%20Documents/specs/Architecture',
+        'https://contoso.sharepoint.com/sites/engineering/Shared%20Documents/specs/Architecture'
+      ),
+      'specs / Architecture'
     );
   });
 


### PR DESCRIPTION
## Summary
- replace raw OneDrive/SharePoint URL fallback snippets with concise location text
- ignore URL-like descriptions so retrieval results do not render as file paths in result cards
- add regression coverage for OneDrive and SharePoint location fallback behavior

## Validation
- npm run compile
- npm run lint
- npm test
- npm run security:check

Closes #44