### PR TITLE
Add plain Copilot chat mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # ContextRelay
 
-ContextRelay is a VS Code extension that surfaces relevant Microsoft 365 context directly in a side panel while you design and code. It provides keyword-first search across Exchange mail, Teams messages, SharePoint sites, OneDrive, OneNote, and Planner tasks — with optional source targeting via slash commands. Pin key snippets and generate timestamped handoff documents (PLAN / TASKS / TEST_PLAN / HANDOFF) so GitHub Copilot can pick up the work fast.
+ContextRelay is a VS Code extension that surfaces relevant Microsoft 365 context directly in a side panel while you design and code. Plain text starts a Microsoft 365 Copilot chat without automatically attaching ContextRelay search context, while slash commands search Exchange mail, Teams messages, SharePoint sites, OneDrive, OneNote, and Planner tasks. Pin key snippets and generate timestamped handoff documents (PLAN / TASKS / TEST_PLAN / HANDOFF) so GitHub Copilot can pick up the work fast.
 
 ---
 
 ## Features
 
-- **Keyword-first search** -- Search across all connected Microsoft 365 sources with a single query.
+- **Plain Copilot chat** -- Type without a slash command to chat directly with Microsoft 365 Copilot in the panel.
+- **Explicit source search** -- Search across connected Microsoft 365 sources with slash commands.
 - **Source targeting via slash commands** -- Narrow results to a specific source instantly.
 
 | Command | Source |
@@ -17,8 +18,8 @@ ContextRelay is a VS Code extension that surfaces relevant Microsoft 365 context
 | `/onedrive <query>` | OneDrive files |
 | `/onenote <query>` | OneNote pages |
 | `/task <query>` | Planner and Microsoft To Do tasks |
-| `/all <query>` | All enabled sources (same as no prefix) |
-| `/ask <instruction>` | Send pinned snippets to Microsoft 365 Copilot and open the reply in a new editor |
+| `/all <query>` | All enabled sources |
+| `/ask <instruction>` | Send pinned snippets to Microsoft 365 Copilot and show the reply in the panel |
 | `/clear` | Clear the chat transcript and discard all pinned snippets |
 
 - **Snippet pinning** -- Save any search result as a named snippet, visible across sessions.
@@ -299,7 +300,7 @@ If you want the smallest possible setup, use one of these patterns.
 - Suitable for:
   - `/mail ...`
   - `/teams ...`
-  - bare query across Mail + Teams
+  - `/all ...` across Mail + Teams
 
 **Pattern 3 — SharePoint / OneDrive search**
 
@@ -501,19 +502,21 @@ from the Command Palette (`Ctrl+Shift+P` / `Cmd+Shift+P`).
 
 On first use, VS Code prompts you to sign in using the built-in Microsoft authentication provider.
 
-### Searching
+### Chatting and Searching
 
-Type a keyword in the search box and press **Enter** to search all enabled sources simultaneously. Results are grouped by source section (Mail / Teams / SharePoint / OneDrive).
+Type a normal message without a slash command and press **Enter** to start or continue a Microsoft 365 Copilot chat. ContextRelay does not automatically search or attach source results for plain chat messages. The response stays in the panel and offers explicit actions to **Copy**, **Append** to the active editor, or **Replace** the active selection/document.
 
-To target a specific source, prefix your query with a slash command:
+To search Microsoft 365 sources, prefix your query with a slash command:
 
 ```
+/all architecture decisions
 /mail project kickoff notes
 /teams sprint review decisions
 /sharepoint API design document
 /onedrive architecture diagram
-/ask Translate the pinned documents into Japanese as markdown
 ```
+
+After you pin snippets or run a search, later chat turns can continue in the same Copilot conversation with that explicit ContextRelay context. The latest visible generated result is also treated as panel context for follow-up turns unless you clear the chat.
 
 ### Building a Handoff from Search Results
 
@@ -554,7 +557,7 @@ Attach `HANDOFF.md` in Copilot Chat using VS Code's context mechanisms (#-mentio
 
 ### `/ask` — Process pinned snippets with Microsoft 365 Copilot
 
-Use `/ask` to let **Microsoft 365 Copilot** (not GitHub Copilot) process your currently pinned snippets and write the answer into a brand-new editor tab.
+Use `/ask` to let **Microsoft 365 Copilot** (not GitHub Copilot) process your currently pinned snippets and show the answer in the ContextRelay panel.
 
 1. Pin one or more documents (`.docx`, SharePoint / OneDrive files, mail, Teams messages). ContextRelay hydrates full document text where possible.
 2. In the chat input, type `/ask` followed by your instruction, for example:
@@ -565,7 +568,7 @@ Use `/ask` to let **Microsoft 365 Copilot** (not GitHub Copilot) process your cu
   /ask Extract every action item as JSON with fields owner, due, task.
   ```
 
-3. ContextRelay sends the pinned content plus your instruction to Microsoft 365 Copilot and opens the response in a new untitled editor. The editor language is auto-detected from the response format (markdown, JSON, HTML, YAML, TypeScript, etc.), so you can save the file with the right extension.
+3. ContextRelay sends the pinned content plus your instruction to Microsoft 365 Copilot and renders the response in the panel. Use the response actions to copy it, append it at the active editor cursor, or replace the active selection/document.
 
 If no snippets are pinned, `/ask` is aborted with a warning. Because this feature relies on the Microsoft 365 Copilot API (preview), you must have a Microsoft 365 Copilot license on the signed-in account and `contextRelay.enableChatPreview` enabled.
 

--- a/src/adapters/chatAdapter.ts
+++ b/src/adapters/chatAdapter.ts
@@ -10,6 +10,21 @@ export interface ChatConversation {
   messages: ChatMessage[];
 }
 
+export interface CopilotContextMessage {
+  text: string;
+  description?: string;
+}
+
+export interface CopilotContextualResources {
+  files?: { uri: string }[];
+  webContext?: { isWebEnabled: boolean };
+}
+
+export interface SendMessageOptions {
+  additionalContext?: CopilotContextMessage[];
+  contextualResources?: CopilotContextualResources;
+}
+
 interface CreateConversationResponse {
   id?: string;
 }
@@ -55,16 +70,36 @@ export async function createConversation(token: string): Promise<string> {
 export async function sendMessage(
   token: string,
   conversationId: string,
-  message: string
+  message: string,
+  options: SendMessageOptions = {}
 ): Promise<string> {
   // Microsoft 365 Copilot Chat API (preview):
   // POST /beta/copilot/conversations/{conversationId}/chat
   // See: https://learn.microsoft.com/microsoft-365/copilot/extensibility/api/ai-services/chat/copilotconversation-chat
   const url = `${GRAPH_BASE}/beta/copilot/conversations/${conversationId}/chat`;
-  const body = JSON.stringify({
+  const requestBody: {
+    message: { text: string };
+    locationHint: { timeZone: string };
+    additionalContext?: CopilotContextMessage[];
+    contextualResources?: CopilotContextualResources;
+  } = {
     message: { text: message },
     locationHint: { timeZone: resolveTimeZone() }
-  });
+  };
+
+  if (options.additionalContext && options.additionalContext.length > 0) {
+    requestBody.additionalContext = options.additionalContext;
+  }
+
+  const contextualResources = options.contextualResources;
+  if (
+    contextualResources &&
+    ((contextualResources.files && contextualResources.files.length > 0) || contextualResources.webContext)
+  ) {
+    requestBody.contextualResources = contextualResources;
+  }
+
+  const body = JSON.stringify(requestBody);
 
   const response = await graphFetchWithRetry(url, token, { method: 'POST', body });
   const data = await handleGraphResponse(response) as ChatResponse;

--- a/src/panel/chatContext.ts
+++ b/src/panel/chatContext.ts
@@ -13,6 +13,10 @@ export interface ChatContextOptions {
   visibleResult?: string;
 }
 
+function buildTruncationSuffix(omittedChars: number): string {
+  return `\n[truncated ${omittedChars} chars]`;
+}
+
 function truncateToBudget(value: string, budget: number): string {
   if (budget <= 0) {
     return '';
@@ -22,12 +26,17 @@ function truncateToBudget(value: string, budget: number): string {
     return value;
   }
 
-  const suffix = `\n[truncated ${value.length - budget} chars]`;
-  if (suffix.length >= budget) {
-    return suffix.slice(0, budget);
+  let suffix = buildTruncationSuffix(value.length);
+  while (suffix.length < budget) {
+    const prefixLength = budget - suffix.length;
+    const nextSuffix = buildTruncationSuffix(value.length - prefixLength);
+    if (nextSuffix === suffix) {
+      return `${value.slice(0, prefixLength)}${suffix}`;
+    }
+    suffix = nextSuffix;
   }
 
-  return `${value.slice(0, budget - suffix.length)}${suffix}`;
+  return suffix.slice(0, budget);
 }
 
 function isFileContextSnippet(snippet: SavedSnippet): boolean {

--- a/src/panel/chatContext.ts
+++ b/src/panel/chatContext.ts
@@ -1,0 +1,112 @@
+import type { CopilotContextMessage, CopilotContextualResources, SendMessageOptions } from '../adapters/chatAdapter';
+import type { SavedSnippet } from '../models/contextItem';
+
+export const MAX_CHAT_CONTEXT_CHARS = 60_000;
+
+export interface ChatContextPayload extends SendMessageOptions {
+  labels: string[];
+}
+
+export interface ChatContextOptions {
+  snippets: SavedSnippet[];
+  searchSummary?: string;
+  visibleResult?: string;
+}
+
+function truncateToBudget(value: string, budget: number): string {
+  if (budget <= 0) {
+    return '';
+  }
+
+  if (value.length <= budget) {
+    return value;
+  }
+
+  const suffix = `\n[truncated ${value.length - budget} chars]`;
+  if (suffix.length >= budget) {
+    return suffix.slice(0, budget);
+  }
+
+  return `${value.slice(0, budget - suffix.length)}${suffix}`;
+}
+
+function isFileContextSnippet(snippet: SavedSnippet): boolean {
+  return (snippet.item.source === 'sharepoint' || snippet.item.source === 'onedrive') &&
+    /^https:\/\//i.test(snippet.item.url?.trim() ?? '');
+}
+
+function addTextContext(
+  additionalContext: CopilotContextMessage[],
+  labels: string[],
+  description: string,
+  text: string,
+  remainingBudget: { value: number }
+): void {
+  const trimmed = text.trim();
+  if (!trimmed || remainingBudget.value <= 0) {
+    return;
+  }
+
+  const truncated = truncateToBudget(trimmed, remainingBudget.value);
+  if (!truncated.trim()) {
+    return;
+  }
+
+  additionalContext.push({ description, text: truncated });
+  labels.push(description);
+  remainingBudget.value -= truncated.length;
+}
+
+export function buildChatContextPayload(options: ChatContextOptions): ChatContextPayload {
+  const additionalContext: CopilotContextMessage[] = [];
+  const contextualResources: CopilotContextualResources = {};
+  const files: { uri: string }[] = [];
+  const labels: string[] = [];
+  const remainingBudget = { value: MAX_CHAT_CONTEXT_CHARS };
+
+  for (const snippet of options.snippets) {
+    if (isFileContextSnippet(snippet) && snippet.item.url) {
+      files.push({ uri: snippet.item.url });
+      labels.push(snippet.name || snippet.item.title);
+      continue;
+    }
+
+    const header = [
+      `Title: ${snippet.name || snippet.item.title}`,
+      `Source: ${snippet.item.source}${snippet.item.url ? ` (${snippet.item.url})` : ''}`
+    ].join('\n');
+    addTextContext(
+      additionalContext,
+      labels,
+      snippet.name || snippet.item.title,
+      `${header}\n\n${snippet.item.snippet}`,
+      remainingBudget
+    );
+  }
+
+  addTextContext(
+    additionalContext,
+    labels,
+    'Latest visible ContextRelay result',
+    options.visibleResult ?? '',
+    remainingBudget
+  );
+
+  addTextContext(
+    additionalContext,
+    labels,
+    'Latest ContextRelay search summary',
+    options.searchSummary ?? '',
+    remainingBudget
+  );
+
+  if (files.length > 0) {
+    contextualResources.files = files;
+  }
+
+  return {
+    ...(additionalContext.length > 0 ? { additionalContext } : {}),
+    ...(contextualResources.files && contextualResources.files.length > 0 ? { contextualResources } : {}),
+    labels
+  };
+}

--- a/src/panel/chatViewProvider.ts
+++ b/src/panel/chatViewProvider.ts
@@ -1,6 +1,6 @@
 import * as crypto from 'crypto';
 import * as vscode from 'vscode';
-import { askCopilot } from '../adapters/chatAdapter';
+import { createConversation, sendMessage } from '../adapters/chatAdapter';
 import { hydrateItemForHandoff } from '../adapters/handoffContentAdapter';
 import { searchMail } from '../adapters/mailAdapter';
 import { searchOneNote } from '../adapters/onenoteAdapter';
@@ -14,7 +14,7 @@ import { DocGenerator, type HandoffContext } from '../docs/docGenerator';
 import { type ContextItem, type ContextSource, type ResolvedPreview, getContextItemKey } from '../models/contextItem';
 import { getHelpText, parseCommand } from '../router/commandRouter';
 import { SnippetStore } from '../snippets/snippetStore';
-import { buildAskPrompt } from './askPrompt';
+import { buildChatContextPayload } from './chatContext';
 import { buildPreviewWebviewHtml } from './openResult';
 import { detectOutputLanguage } from './outputLanguage';
 import { resolvePreview } from './previewResolver';
@@ -47,6 +47,7 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
   private readonly hosts = new Map<ChatHostKind, ChatHostSession>();
   private static readonly MAX_TRANSCRIPT_LENGTH = 200;
   private transcript: HostToWebviewMessage[] = [];
+  private currentConversationId?: string;
   private editorPanel?: vscode.WebviewPanel;
   private previewPanel?: vscode.WebviewPanel;
 
@@ -122,7 +123,15 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
   }
 
   public clearChat(): void {
+    this.resetChatState();
+  }
+
+  private resetChatState(): void {
+    this.snippetStore.clear();
+    this.latestSearchSummary = undefined;
+    this.currentConversationId = undefined;
     this.postMessage({ command: 'clearChat' });
+    this.sendPinnedItems();
   }
 
   public clearCache(): void {
@@ -212,6 +221,9 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
       case 'copySnippet':
         await this.handleCopySnippet(message.text);
         break;
+      case 'applyAssistantResult':
+        await this.handleApplyAssistantResult(message.action, message.text);
+        break;
       case 'pinSnippet':
         await this.handlePinSnippet(message.item);
         break;
@@ -236,6 +248,53 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
 
     await vscode.env.clipboard.writeText(text);
     vscode.window.showInformationMessage('ContextRelay: Text copied to clipboard.');
+  }
+
+  private async handleApplyAssistantResult(action: 'copy' | 'append' | 'replace', text: string): Promise<void> {
+    if (!text?.trim()) {
+      vscode.window.showWarningMessage('ContextRelay: There is no assistant result to apply.');
+      return;
+    }
+
+    if (action === 'copy') {
+      await vscode.env.clipboard.writeText(text);
+      vscode.window.showInformationMessage('ContextRelay: Copilot response copied to clipboard.');
+      return;
+    }
+
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) {
+      vscode.window.showErrorMessage('ContextRelay: Open an editor before appending or replacing content.');
+      return;
+    }
+
+    const editApplied = await editor.edit(editBuilder => {
+      if (action === 'append') {
+        editBuilder.insert(editor.selection.active, text);
+        return;
+      }
+
+      const range = editor.selection.isEmpty
+        ? this.getWholeDocumentRange(editor.document)
+        : editor.selection;
+      editBuilder.replace(range, text);
+    });
+
+    if (!editApplied) {
+      vscode.window.showErrorMessage('ContextRelay: Failed to update the active editor.');
+      return;
+    }
+
+    vscode.window.showInformationMessage(
+      action === 'append'
+        ? 'ContextRelay: Copilot response appended to the active editor.'
+        : 'ContextRelay: Copilot response replaced the active editor content.'
+    );
+  }
+
+  private getWholeDocumentRange(document: vscode.TextDocument): vscode.Range {
+    const lastLine = document.lineAt(Math.max(0, document.lineCount - 1));
+    return new vscode.Range(new vscode.Position(0, 0), lastLine.range.end);
   }
 
   private async handlePinSnippet(item: ContextItem): Promise<void> {
@@ -327,6 +386,11 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
 
     if (parsed.target === 'ask') {
       await this.handleAskCommand(parsed.query);
+      return;
+    }
+
+    if (parsed.target === 'chat') {
+      await this.handlePlainChat(parsed.query);
       return;
     }
 
@@ -431,10 +495,7 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
 
   private handleClearCommand(): void {
     const hadSnippets = this.snippetStore.getAll().length > 0;
-    this.snippetStore.clear();
-    this.latestSearchSummary = undefined;
-    this.postMessage({ command: 'clearChat' });
-    this.sendPinnedItems();
+    this.resetChatState();
     const text = hadSnippets
       ? 'Chat cleared. All pinned snippets discarded.'
       : 'Chat cleared.';
@@ -460,6 +521,31 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
       return;
     }
 
+    await this.handleCopilotChat(prompt, 'ask', true);
+  }
+
+  private async handlePlainChat(prompt: string): Promise<void> {
+    await this.handleCopilotChat(prompt, 'chat', false);
+  }
+
+  private async handleCopilotChat(
+    prompt: string,
+    kind: 'chat' | 'ask',
+    requirePinnedContext: boolean
+  ): Promise<void> {
+    const snippets = this.snippetStore.getAll();
+    if (requirePinnedContext && snippets.length === 0) {
+      const message = 'Pin one or more snippets first to use /ask. The pinned content is sent to Microsoft 365 Copilot as context.';
+      vscode.window.showWarningMessage(`ContextRelay: ${message}`);
+      this.postMessage({
+        command: 'queryError',
+        source: 'all',
+        message,
+        timestamp: new Date().toISOString()
+      });
+      return;
+    }
+
     let token: string;
     try {
       token = await this.authProvider.getAccessToken();
@@ -474,25 +560,43 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
       return;
     }
 
-    this.postMessage({ command: 'loading', source: 'all', isLoading: true });
+    this.postMessage({
+      command: 'loading',
+      source: 'all',
+      isLoading: true,
+      text: 'Thinking...',
+      icon: '🧠'
+    });
 
     try {
-      const fullPrompt = buildAskPrompt(prompt, snippets);
-      const reply = await askCopilot(token, fullPrompt);
-      const { language, content } = detectOutputLanguage(prompt, reply);
+      if (!this.currentConversationId) {
+        this.currentConversationId = await createConversation(token);
+      }
 
-      const doc = await vscode.workspace.openTextDocument({ language, content });
-      await vscode.window.showTextDocument(doc, { preview: false });
+      // Conversation history is preserved by the Copilot Chat API via the
+      // conversation id, so we do not re-send the previous Copilot reply as
+      // additional context. Only explicit user-added context (pinned snippets
+      // and the latest search summary) is forwarded.
+      const contextPayload = buildChatContextPayload({
+        snippets,
+        searchSummary: this.latestSearchSummary
+      });
+      const reply = await sendMessage(token, this.currentConversationId, prompt, contextPayload);
+      if (!reply.trim()) {
+        throw new Error('Microsoft 365 Copilot returned an empty response.');
+      }
 
+      const { content } = detectOutputLanguage(prompt, reply);
       this.postMessage({
         command: 'assistantMessage',
-        kind: 'ask',
-        text: `Microsoft 365 Copilot response opened in a new editor (${language}). ${snippets.length} pinned snippet(s) used as context.`,
+        kind,
+        text: content,
+        contextLabels: contextPayload.labels,
         timestamp: new Date().toISOString()
       });
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      vscode.window.showErrorMessage(`ContextRelay: /ask failed — ${message}`);
+      vscode.window.showErrorMessage(`ContextRelay: Copilot chat failed — ${message}`);
       this.postMessage({
         command: 'queryError',
         source: 'all',
@@ -785,10 +889,41 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
       border-bottom-left-radius: 2px;
     }
 
+    .message-text {
+      white-space: pre-wrap;
+    }
+
+    .context-used {
+      margin-top: var(--cr-spacing-xs);
+      font-size: 0.75em;
+      color: var(--vscode-descriptionForeground);
+    }
+
     .message .timestamp {
       font-size: 0.75em;
       opacity: 0.6;
       margin-top: var(--cr-spacing-xs);
+    }
+
+    .assistant-actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: var(--cr-spacing-xs);
+      margin-top: var(--cr-spacing-sm);
+    }
+
+    .assistant-actions button {
+      background: none;
+      border: 1px solid var(--vscode-button-secondaryBackground, var(--vscode-input-border, #555));
+      color: var(--vscode-foreground);
+      padding: 2px 8px;
+      border-radius: 3px;
+      font-size: 0.8em;
+      cursor: pointer;
+    }
+
+    .assistant-actions button:hover {
+      background: var(--vscode-list-hoverBackground);
     }
 
     .result-card {
@@ -940,6 +1075,13 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
       color: var(--vscode-input-placeholderForeground);
     }
 
+    #promptInput:disabled {
+      opacity: 0.65;
+      cursor: not-allowed;
+      background: var(--vscode-input-background);
+      color: var(--vscode-disabledForeground, var(--vscode-input-placeholderForeground));
+    }
+
     #sendButton {
       width: 32px;
       height: 32px;
@@ -959,8 +1101,15 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
     }
 
     #sendButton:disabled {
-      opacity: 0.5;
+      background: var(--vscode-button-secondaryBackground, var(--vscode-input-background));
+      color: var(--vscode-disabledForeground, var(--vscode-button-secondaryForeground));
+      border: 1px solid var(--vscode-button-border, var(--vscode-input-border, transparent));
+      opacity: 0.65;
       cursor: not-allowed;
+    }
+
+    #sendButton:disabled:hover {
+      background: var(--vscode-button-secondaryBackground, var(--vscode-input-background));
     }
 
     #inputHint {
@@ -1023,9 +1172,9 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
     <div id="chatArea" role="log" aria-live="polite" aria-label="Chat messages">
       <div class="welcome" id="welcome">
         <h2>ContextRelay</h2>
-        <p>Search Microsoft 365 context with slash commands.</p>
-        <p style="font-size: 0.8em;">Type <code>/</code> for available commands, or enter a keyword to search all sources.</p>
-        <p style="font-size: 0.8em;">Pin snippets and run <code>/ask</code> to process them with Microsoft 365 Copilot and open the result in a new editor.</p>
+        <p>Chat with Microsoft 365 Copilot, or search Microsoft 365 context with slash commands.</p>
+        <p style="font-size: 0.8em;">Type <code>/</code> for source search commands. Plain text starts or continues chat.</p>
+        <p style="font-size: 0.8em;">Pin snippets and run <code>/ask</code> to process them with Microsoft 365 Copilot in the panel.</p>
       </div>
     </div>
 
@@ -1036,19 +1185,19 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
         <textarea
           id="promptInput"
           rows="1"
-          placeholder="Search M365 context... (type / for commands)"
-          aria-label="Search query input"
+          placeholder="Ask Copilot, or type / for source search"
+          aria-label="Copilot chat or source search input"
           aria-haspopup="listbox"
           aria-controls="slashMenu"
         ></textarea>
-        <button id="sendButton" aria-label="Send query" title="Send">
+        <button id="sendButton" aria-label="Send message" title="Send">
           <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
             <path d="M1 1.91L7.2 8 1 14.09 1.91 15 9 8 1.91 1z"/>
             <path d="M7 1.91L13.2 8 7 14.09 7.91 15 15 8 7.91 1z"/>
           </svg>
         </button>
       </div>
-      <div id="inputHint">Press Enter to send • Shift+Enter for new line • Type / for commands</div>
+      <div id="inputHint">Press Enter to send • Shift+Enter for new line • Type / for source search commands</div>
     </div>
   </div>
 

--- a/src/panel/chatViewProvider.ts
+++ b/src/panel/chatViewProvider.ts
@@ -41,6 +41,7 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
   public static readonly viewType = CHAT_VIEW_ID;
 
   private latestSearchSummary?: string;
+  private latestVisibleResult?: string;
   private readonly cache: CacheStore<ContextItem[]>;
   private readonly snippetStore: SnippetStore;
   private readonly docGenerator: DocGenerator;
@@ -129,6 +130,7 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
   private resetChatState(): void {
     this.snippetStore.clear();
     this.latestSearchSummary = undefined;
+    this.latestVisibleResult = undefined;
     this.currentConversationId = undefined;
     this.postMessage({ command: 'clearChat' });
     this.sendPinnedItems();
@@ -508,19 +510,6 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
   }
 
   private async handleAskCommand(prompt: string): Promise<void> {
-    const snippets = this.snippetStore.getAll();
-    if (snippets.length === 0) {
-      const message = 'Pin one or more snippets first to use /ask. The pinned content is sent to Microsoft 365 Copilot as context.';
-      vscode.window.showWarningMessage(`ContextRelay: ${message}`);
-      this.postMessage({
-        command: 'queryError',
-        source: 'all',
-        message,
-        timestamp: new Date().toISOString()
-      });
-      return;
-    }
-
     await this.handleCopilotChat(prompt, 'ask', true);
   }
 
@@ -574,12 +563,13 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
       }
 
       // Conversation history is preserved by the Copilot Chat API via the
-      // conversation id, so we do not re-send the previous Copilot reply as
-      // additional context. Only explicit user-added context (pinned snippets
-      // and the latest search summary) is forwarded.
+      // conversation id, so we only forward explicit ContextRelay context:
+      // pinned snippets, the latest visible generated result, and the latest
+      // search summary.
       const contextPayload = buildChatContextPayload({
         snippets,
-        searchSummary: this.latestSearchSummary
+        searchSummary: this.latestSearchSummary,
+        visibleResult: this.latestVisibleResult
       });
       const reply = await sendMessage(token, this.currentConversationId, prompt, contextPayload);
       if (!reply.trim()) {
@@ -587,6 +577,7 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
       }
 
       const { content } = detectOutputLanguage(prompt, reply);
+      this.latestVisibleResult = content;
       this.postMessage({
         command: 'assistantMessage',
         kind,

--- a/src/panel/types.ts
+++ b/src/panel/types.ts
@@ -40,13 +40,20 @@ export interface CopySnippetMessage {
   text: string;
 }
 
+export interface ApplyAssistantResultMessage {
+  command: 'applyAssistantResult';
+  action: 'copy' | 'append' | 'replace';
+  text: string;
+}
+
 export type WebviewToHostMessage =
   | SubmitQueryMessage
   | WebviewReadyMessage
   | PinSnippetMessage
   | OpenLinkMessage
   | OpenItemMessage
-  | CopySnippetMessage;
+  | CopySnippetMessage
+  | ApplyAssistantResultMessage;
 
 // --- Messages: Extension host → Webview ---
 
@@ -75,6 +82,8 @@ export interface LoadingMessage {
   command: 'loading';
   source: ContextSource | 'all';
   isLoading: boolean;
+  text?: string;
+  icon?: string;
 }
 
 export interface SlashHelpMessage {
@@ -91,7 +100,8 @@ export interface AssistantMessage {
   command: 'assistantMessage';
   text: string;
   timestamp: string;
-  kind?: 'info' | 'ask';
+  kind?: 'info' | 'ask' | 'chat';
+  contextLabels?: string[];
 }
 
 export interface PinnedItemsMessage {

--- a/src/router/commandRouter.ts
+++ b/src/router/commandRouter.ts
@@ -1,6 +1,7 @@
 import type { ContextSource } from '../models/contextItem';
 
 export type RouteTarget =
+  | 'chat'
   | 'mail'
   | 'teams'
   | 'sharepoint'
@@ -56,12 +57,12 @@ export function parseCommand(input: string): ParsedCommand {
 
   if (!trimmed.startsWith('/')) {
     return {
-      target: 'all',
+      target: 'chat',
       query: normalized,
       isEmpty: normalized.length === 0,
-      targetSources: ALL_SOURCES,
+      targetSources: [],
       sourceCommands: [],
-      searchScope: 'all'
+      searchScope: 'operation'
     };
   }
 
@@ -183,8 +184,8 @@ export function getHelpText(command: string | readonly SearchCommandName[]): str
     onenote: 'Example: /onenote architecture decision log\nExample: /onenote section notebook architecture',
     planner: 'Example: /task release checklist\nExample: /task metadata comments onboarding',
     task: 'Example: /task release checklist\nExample: /task metadata comments onboarding',
-    all: 'Example: /all architecture decisions\nExample: /mail /onedrive architecture decisions\nOr just type a query without a slash command.',
-    ask: 'Example: /ask 日本語に翻訳してmarkdownにして\nExample: /ask Summarize the pinned docs as a bullet list\nPinned snippets are used as context and the Microsoft 365 Copilot response is opened in a new editor tab.',
+    all: 'Example: /all architecture decisions\nExample: /mail /onedrive architecture decisions\nPlain text without a slash command starts or continues a Microsoft 365 Copilot chat.',
+    ask: 'Example: /ask 日本語に翻訳してmarkdownにして\nExample: /ask Summarize the pinned docs as a bullet list\nPinned snippets are used as context and the Microsoft 365 Copilot response is shown in the panel.',
     clear: 'Example: /clear\nClears the current chat transcript and discards all pinned snippets.'
   };
   return examples[commandName] ?? 'Type a query to search Microsoft 365 content.';

--- a/src/test/suite/chatAdapter.test.ts
+++ b/src/test/suite/chatAdapter.test.ts
@@ -91,6 +91,39 @@ suite('Chat adapter', () => {
     }
   });
 
+  test('sendMessage includes additional context and contextual resources when provided', async () => {
+    const stub = installFetchStub(() => ({
+      status: 200,
+      body: {
+        messages: [
+          { text: 'question' },
+          { text: 'answer' }
+        ]
+      }
+    }));
+    try {
+      const reply = await sendMessage('token-abc', 'conv-123', 'question', {
+        additionalContext: [
+          { description: 'Pinned note', text: 'Important context' }
+        ],
+        contextualResources: {
+          files: [{ uri: 'https://contoso.sharepoint.com/sites/docs/a.docx' }]
+        }
+      });
+
+      assert.equal(reply, 'answer');
+      const body = JSON.parse(String(stub.captured[0].init.body));
+      assert.deepEqual(body.additionalContext, [
+        { description: 'Pinned note', text: 'Important context' }
+      ]);
+      assert.deepEqual(body.contextualResources.files, [
+        { uri: 'https://contoso.sharepoint.com/sites/docs/a.docx' }
+      ]);
+    } finally {
+      stub.restore();
+    }
+  });
+
   test('sendMessage skips echoed prompt when selecting assistant reply', async () => {
     const stub = installFetchStub(() => ({
       status: 200,

--- a/src/test/suite/chatContext.test.ts
+++ b/src/test/suite/chatContext.test.ts
@@ -1,0 +1,64 @@
+import { strict as assert } from 'assert';
+import { buildChatContextPayload, MAX_CHAT_CONTEXT_CHARS } from '../../panel/chatContext';
+import type { SavedSnippet } from '../../models/contextItem';
+
+function snippet(source: SavedSnippet['item']['source'], name: string, body: string, url?: string): SavedSnippet {
+  return {
+    id: `s-${name}`,
+    name,
+    savedAt: '2026-04-30T00:00:00.000Z',
+    item: {
+      source,
+      title: name,
+      snippet: body,
+      url,
+      cache: { hit: false }
+    }
+  };
+}
+
+suite('chatContext', () => {
+  test('returns no ContextRelay context when nothing has been added', () => {
+    const payload = buildChatContextPayload({ snippets: [] });
+    assert.equal(payload.additionalContext, undefined);
+    assert.equal(payload.contextualResources, undefined);
+    assert.deepEqual(payload.labels, []);
+  });
+
+  test('uses SharePoint and OneDrive snippet URLs as file contextual resources', () => {
+    const payload = buildChatContextPayload({
+      snippets: [
+        snippet('sharepoint', 'spec.docx', 'body', 'https://contoso.sharepoint.com/sites/docs/spec.docx'),
+        snippet('onedrive', 'plan.docx', 'body', 'https://contoso-my.sharepoint.com/personal/docs/plan.docx')
+      ]
+    });
+
+    assert.deepEqual(payload.contextualResources?.files, [
+      { uri: 'https://contoso.sharepoint.com/sites/docs/spec.docx' },
+      { uri: 'https://contoso-my.sharepoint.com/personal/docs/plan.docx' }
+    ]);
+    assert.deepEqual(payload.labels, ['spec.docx', 'plan.docx']);
+  });
+
+  test('uses non-file snippets and visible result as additional context', () => {
+    const payload = buildChatContextPayload({
+      snippets: [snippet('teams', 'standup', 'Release is blocked by test failures.')],
+      visibleResult: 'Draft answer from the panel'
+    });
+
+    assert.equal(payload.additionalContext?.length, 2);
+    assert.ok(payload.additionalContext?.[0].text.includes('Release is blocked'));
+    assert.ok(payload.additionalContext?.[1].text.includes('Draft answer'));
+    assert.ok(payload.labels.includes('Latest visible ContextRelay result'));
+  });
+
+  test('caps additional context to the shared budget', () => {
+    const payload = buildChatContextPayload({
+      snippets: [snippet('teams', 'huge', 'x'.repeat(MAX_CHAT_CONTEXT_CHARS * 2))]
+    });
+
+    const length = payload.additionalContext?.reduce((total, item) => total + item.text.length, 0) ?? 0;
+    assert.ok(length <= MAX_CHAT_CONTEXT_CHARS);
+    assert.ok(payload.additionalContext?.[0].text.includes('truncated'));
+  });
+});

--- a/src/test/suite/chatContext.test.ts
+++ b/src/test/suite/chatContext.test.ts
@@ -61,4 +61,20 @@ suite('chatContext', () => {
     assert.ok(length <= MAX_CHAT_CONTEXT_CHARS);
     assert.ok(payload.additionalContext?.[0].text.includes('truncated'));
   });
+
+  test('reports the number of omitted characters after accounting for the suffix length', () => {
+    const oversizedBody = 'x'.repeat(MAX_CHAT_CONTEXT_CHARS * 2);
+    const payload = buildChatContextPayload({
+      snippets: [snippet('teams', 'huge', oversizedBody)]
+    });
+
+    const text = payload.additionalContext?.[0].text ?? '';
+    const suffixIndex = text.indexOf('\n[truncated ');
+    const match = text.match(/\[truncated (\d+) chars\]$/);
+    assert.ok(suffixIndex > 0);
+    assert.ok(match);
+
+    const original = `Title: huge\nSource: teams\n\n${oversizedBody}`;
+    assert.equal(Number(match?.[1]), original.length - suffixIndex);
+  });
 });

--- a/src/test/suite/chatViewProvider.test.ts
+++ b/src/test/suite/chatViewProvider.test.ts
@@ -1,0 +1,235 @@
+import { strict as assert } from 'assert';
+import Module from 'module';
+import type * as vscode from 'vscode';
+
+type ChatViewProviderClass = typeof import('../../panel/chatViewProvider').ChatViewProvider;
+type ModuleLoader = typeof Module & {
+  _load: (request: string, parent: object | null | undefined, isMain: boolean) => unknown;
+};
+
+const moduleLoader = Module as unknown as ModuleLoader;
+const originalLoad = moduleLoader._load;
+let ChatViewProvider: ChatViewProviderClass;
+
+const configValues = new Map<string, unknown>();
+const warningMessages: string[] = [];
+const errorMessages: string[] = [];
+const infoMessages: string[] = [];
+const capturedPayloads: Array<unknown> = [];
+let replies: string[] = [];
+
+class InMemoryMemento implements vscode.Memento {
+  private readonly store = new Map<string, unknown>();
+
+  keys(): readonly string[] {
+    return [...this.store.keys()];
+  }
+
+  get<T>(key: string): T | undefined;
+  get<T>(key: string, defaultValue: T): T;
+  get<T>(key: string, defaultValue?: T): T | undefined {
+    if (this.store.has(key)) {
+      return this.store.get(key) as T;
+    }
+
+    return defaultValue;
+  }
+
+  async update(key: string, value: unknown): Promise<void> {
+    if (value === undefined) {
+      this.store.delete(key);
+      return;
+    }
+
+    this.store.set(key, value);
+  }
+}
+
+function createContext(): vscode.ExtensionContext {
+  return {
+    subscriptions: [],
+    workspaceState: new InMemoryMemento()
+  } as unknown as vscode.ExtensionContext;
+}
+
+function createVscodeStub(): typeof vscode {
+  return {
+    workspace: {
+      getConfiguration: () => ({
+        get: <T>(key: string, defaultValue: T): T =>
+          (configValues.has(key) ? configValues.get(key) : defaultValue) as T
+      })
+    },
+    window: {
+      showWarningMessage: async (message: string) => {
+        warningMessages.push(message);
+        return undefined;
+      },
+      showErrorMessage: async (message: string) => {
+        errorMessages.push(message);
+        return undefined;
+      },
+      showInformationMessage: async (message: string) => {
+        infoMessages.push(message);
+        return undefined;
+      }
+    },
+    env: {
+      openExternal: async () => true,
+      clipboard: {
+        writeText: async () => undefined
+      }
+    },
+    Uri: {
+      parse: (value: string) => ({ scheme: value.split(':', 1)[0] })
+    }
+  } as unknown as typeof vscode;
+}
+
+suite('ChatViewProvider', () => {
+  suiteSetup(async () => {
+    moduleLoader._load = (request: string, parent: object | null | undefined, isMain: boolean): unknown => {
+      if (request === 'vscode') {
+        return createVscodeStub();
+      }
+
+      if (request === '../adapters/chatAdapter') {
+        return {
+          createConversation: async () => 'conv-1',
+          sendMessage: async (_token: string, _conversationId: string, _prompt: string, payload?: unknown) => {
+            capturedPayloads.push(payload);
+            return replies.shift() ?? 'stub reply';
+          }
+        };
+      }
+
+      if (request === '../adapters/handoffContentAdapter') {
+        return {
+          hydrateItemForHandoff: async (_token: string, item: unknown) => item
+        };
+      }
+
+      if (request === '../adapters/mailAdapter') {
+        return { searchMail: async () => [] };
+      }
+
+      if (request === '../adapters/onenoteAdapter') {
+        return { searchOneNote: async () => [] };
+      }
+
+      if (request === '../adapters/plannerAdapter') {
+        return { searchPlanner: async () => [] };
+      }
+
+      if (request === '../adapters/retrievalAdapter') {
+        return { searchRetrieval: async () => [] };
+      }
+
+      if (request === '../adapters/teamsAdapter') {
+        return { searchTeams: async () => [] };
+      }
+
+      if (request === '../adapters/todoAdapter') {
+        return { searchTodo: async () => [] };
+      }
+
+      if (request === '../docs/docGenerator') {
+        return {
+          DocGenerator: class {}
+        };
+      }
+
+      if (request === './openResult') {
+        return {
+          buildPreviewWebviewHtml: () => ''
+        };
+      }
+
+      if (request === './outputLanguage') {
+        return {
+          detectOutputLanguage: (_prompt: string, reply: string) => ({ content: reply })
+        };
+      }
+
+      if (request === './previewResolver') {
+        return {
+          resolvePreview: async () => undefined
+        };
+      }
+
+      return originalLoad(request, parent, isMain);
+    };
+
+    try {
+      ({ ChatViewProvider } = await import('../../panel/chatViewProvider'));
+    } finally {
+      moduleLoader._load = originalLoad;
+    }
+  });
+
+  setup(() => {
+    configValues.clear();
+    warningMessages.length = 0;
+    errorMessages.length = 0;
+    infoMessages.length = 0;
+    capturedPayloads.length = 0;
+    replies = ['First answer', 'Second answer'];
+  });
+
+  test('includes the latest visible result in follow-up Copilot chat context', async () => {
+    const provider = new ChatViewProvider(
+      createContext(),
+      { getAccessToken: async () => 'token-123' } as never,
+      {} as never
+    );
+
+    await (provider as unknown as { handlePlainChat(prompt: string): Promise<void> }).handlePlainChat('first prompt');
+    await (provider as unknown as { handlePlainChat(prompt: string): Promise<void> }).handlePlainChat('follow-up prompt');
+
+    assert.equal(capturedPayloads.length, 2);
+    assert.equal((capturedPayloads[0] as { additionalContext?: unknown }).additionalContext, undefined);
+
+    const secondPayload = capturedPayloads[1] as {
+      additionalContext?: Array<{ description: string; text: string }>;
+      labels: string[];
+    };
+    assert.ok(secondPayload.additionalContext?.some(item =>
+      item.description === 'Latest visible ContextRelay result' && item.text.includes('First answer')
+    ));
+    assert.ok(secondPayload.labels.includes('Latest visible ContextRelay result'));
+  });
+
+  test('clearChat removes the latest visible result from future context payloads', async () => {
+    const provider = new ChatViewProvider(
+      createContext(),
+      { getAccessToken: async () => 'token-123' } as never,
+      {} as never
+    );
+
+    await (provider as unknown as { handlePlainChat(prompt: string): Promise<void> }).handlePlainChat('first prompt');
+    provider.clearChat();
+    await (provider as unknown as { handlePlainChat(prompt: string): Promise<void> }).handlePlainChat('after clear');
+
+    const secondPayload = capturedPayloads[1] as {
+      additionalContext?: Array<{ description: string; text: string }>;
+      labels: string[];
+    };
+    assert.equal(secondPayload.additionalContext, undefined);
+    assert.deepEqual(secondPayload.labels, []);
+  });
+
+  test('ask without pinned snippets surfaces a single guard message and skips Copilot calls', async () => {
+    const provider = new ChatViewProvider(
+      createContext(),
+      { getAccessToken: async () => 'token-123' } as never,
+      {} as never
+    );
+
+    await (provider as unknown as { handleAskCommand(prompt: string): Promise<void> }).handleAskCommand('need a summary');
+
+    assert.equal(warningMessages.length, 1);
+    assert.equal(capturedPayloads.length, 0);
+    assert.equal(errorMessages.length, 0);
+    assert.equal(infoMessages.length, 0);
+  });
+});

--- a/src/test/suite/commandRouter.test.ts
+++ b/src/test/suite/commandRouter.test.ts
@@ -2,11 +2,13 @@ import { strict as assert } from 'assert';
 import { parseCommand, getHelpText } from '../../router/commandRouter';
 
 suite('CommandRouter', () => {
-  test('bare query routes to all', () => {
+  test('bare query routes to chat without source context', () => {
     const result = parseCommand('architecture decisions');
-    assert.equal(result.target, 'all');
+    assert.equal(result.target, 'chat');
     assert.equal(result.query, 'architecture decisions');
     assert.equal(result.isEmpty, false);
+    assert.deepEqual(result.targetSources, []);
+    assert.equal(result.searchScope, 'operation');
   });
 
   test('/mail command routes to mail', () => {
@@ -58,7 +60,7 @@ suite('CommandRouter', () => {
 
   test('bare multiline query is normalized', () => {
     const result = parseCommand('LendHub_Requirements\nDocument\tFictional.docx');
-    assert.equal(result.target, 'all');
+    assert.equal(result.target, 'chat');
     assert.equal(result.query, 'LendHub_Requirements Document Fictional.docx');
     assert.equal(result.isEmpty, false);
   });
@@ -150,7 +152,7 @@ suite('CommandRouter', () => {
   test('empty input is isEmpty', () => {
     const result = parseCommand('');
     assert.equal(result.isEmpty, true);
-    assert.equal(result.target, 'all');
+    assert.equal(result.target, 'chat');
   });
 
   test('whitespace-only input is isEmpty', () => {
@@ -196,6 +198,12 @@ suite('CommandRouter', () => {
   test('getHelpText for ask mentions Microsoft 365 Copilot', () => {
     const text = getHelpText('ask');
     assert.ok(text.toLowerCase().includes('microsoft 365 copilot'));
+  });
+
+  test('getHelpText for all explains plain text is chat', () => {
+    const text = getHelpText('all');
+    assert.ok(text.toLowerCase().includes('plain text'));
+    assert.ok(text.toLowerCase().includes('chat'));
   });
 
   test('/clear command routes to clear with empty query but is not isEmpty', () => {

--- a/src/webview/chatRenderer.ts
+++ b/src/webview/chatRenderer.ts
@@ -130,7 +130,12 @@ export class ChatRenderer {
   /**
    * Render a plain assistant text message (used by /ask for status updates).
    */
-  renderAssistantMessage(text: string, timestamp: string): void {
+  renderAssistantMessage(
+    text: string,
+    timestamp: string,
+    kind?: 'info' | 'ask' | 'chat',
+    contextLabels: string[] = []
+  ): void {
     this.hideWelcome();
 
     const el = document.createElement('div');
@@ -138,8 +143,20 @@ export class ChatRenderer {
     el.setAttribute('role', 'article');
 
     const textDiv = document.createElement('div');
+    textDiv.className = 'message-text';
     textDiv.textContent = text;
     el.appendChild(textDiv);
+
+    if (contextLabels.length > 0) {
+      const contextDiv = document.createElement('div');
+      contextDiv.className = 'context-used';
+      contextDiv.textContent = `Context: ${contextLabels.join(', ')}`;
+      el.appendChild(contextDiv);
+    }
+
+    if (kind === 'chat' || kind === 'ask') {
+      el.appendChild(this.buildAssistantActions(text));
+    }
 
     const timeStr = this.formatTime(timestamp);
     if (timeStr) {
@@ -151,6 +168,37 @@ export class ChatRenderer {
 
     this.chatArea.appendChild(el);
     this.scrollToBottom();
+  }
+
+  private buildAssistantActions(text: string): HTMLElement {
+    const actions = document.createElement('div');
+    actions.className = 'assistant-actions';
+
+    const copyBtn = this.buildAssistantActionButton('Copy', 'Copy response', () => {
+      this.vscode.postMessage({ command: 'applyAssistantResult', action: 'copy', text });
+    });
+    actions.appendChild(copyBtn);
+
+    const appendBtn = this.buildAssistantActionButton('Append', 'Append response to the active editor', () => {
+      this.vscode.postMessage({ command: 'applyAssistantResult', action: 'append', text });
+    });
+    actions.appendChild(appendBtn);
+
+    const replaceBtn = this.buildAssistantActionButton('Replace', 'Replace the active selection, or the whole active document if nothing is selected', () => {
+      this.vscode.postMessage({ command: 'applyAssistantResult', action: 'replace', text });
+    });
+    actions.appendChild(replaceBtn);
+
+    return actions;
+  }
+
+  private buildAssistantActionButton(label: string, title: string, onClick: () => void): HTMLButtonElement {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.textContent = label;
+    button.title = title;
+    button.addEventListener('click', onClick);
+    return button;
   }
 
   /**
@@ -226,23 +274,24 @@ export class ChatRenderer {
   /**
    * Show or hide a loading indicator for a source.
    */
-  setLoading(source: string, isLoading: boolean): void {
+  setLoading(source: string, isLoading: boolean, message?: string, icon?: string): void {
     if (isLoading) {
       this.hideWelcome();
 
       const el = document.createElement('div');
       el.className = 'loading';
-      el.setAttribute('aria-label', `Loading ${getSourceLabel(source)} results`);
+      const label = getSourceLabel(source);
+      const loadingText = message ?? `Searching ${label}...`;
+      el.setAttribute('aria-label', loadingText);
 
       const spinner = document.createElement('div');
       spinner.className = 'spinner';
       spinner.setAttribute('aria-hidden', 'true');
       el.appendChild(spinner);
 
-      const label = getSourceLabel(source);
       const text = document.createElement('span');
-      text.appendChild(this.createSourceIcon(source, '🔍'));
-      text.appendChild(document.createTextNode(` Searching ${label}...`));
+      text.appendChild(icon ? this.createTextIcon(icon) : this.createSourceIcon(source, '🔍'));
+      text.appendChild(document.createTextNode(` ${loadingText}`));
       el.appendChild(text);
 
       this.loadingElements.set(source, el);
@@ -300,7 +349,7 @@ export class ChatRenderer {
     welcome.appendChild(heading);
 
     const intro = document.createElement('p');
-    intro.textContent = 'Search Microsoft 365 context with slash commands.';
+    intro.textContent = 'Chat with Microsoft 365 Copilot, or search Microsoft 365 context with slash commands.';
     welcome.appendChild(intro);
 
     const commandsHint = document.createElement('p');
@@ -313,7 +362,7 @@ export class ChatRenderer {
     const comboCode = document.createElement('code');
     comboCode.textContent = '/mail /onedrive';
     commandsHint.appendChild(comboCode);
-    commandsHint.appendChild(document.createTextNode(', or enter a keyword to search all sources.'));
+    commandsHint.appendChild(document.createTextNode(' for source search. Plain text starts or continues chat.'));
     welcome.appendChild(commandsHint);
 
     const askHint = document.createElement('p');
@@ -322,7 +371,7 @@ export class ChatRenderer {
     const askCode = document.createElement('code');
     askCode.textContent = '/ask';
     askHint.appendChild(askCode);
-    askHint.appendChild(document.createTextNode(' to process them with Microsoft 365 Copilot.'));
+    askHint.appendChild(document.createTextNode(' to process pinned context with Microsoft 365 Copilot.'));
     welcome.appendChild(askHint);
 
     this.chatArea.appendChild(welcome);
@@ -437,6 +486,18 @@ export class ChatRenderer {
   }
 
   private createSourceIcon(source: string, fallback: string): HTMLElement {
+    const iconSpan = this.createTextIcon('');
+    const svg = getSourceInlineSvg(source);
+    if (svg) {
+      iconSpan.appendChild(this.buildSvgIcon(svg));
+      return iconSpan;
+    }
+
+    iconSpan.textContent = getSourceTextIcon(source) || fallback;
+    return iconSpan;
+  }
+
+  private createTextIcon(icon: string): HTMLElement {
     const iconSpan = document.createElement('span');
     iconSpan.className = 'source-icon';
     iconSpan.setAttribute('aria-hidden', 'true');
@@ -447,14 +508,7 @@ export class ChatRenderer {
     iconSpan.style.height = '1em';
     iconSpan.style.marginRight = '6px';
     iconSpan.style.verticalAlign = 'text-bottom';
-
-    const svg = getSourceInlineSvg(source);
-    if (svg) {
-      iconSpan.appendChild(this.buildSvgIcon(svg));
-      return iconSpan;
-    }
-
-    iconSpan.textContent = getSourceTextIcon(source) || fallback;
+    iconSpan.textContent = icon;
     return iconSpan;
   }
 

--- a/src/webview/main.ts
+++ b/src/webview/main.ts
@@ -27,6 +27,8 @@ const slashMenuEl = document.getElementById('slashMenu')!;
 
 // --- Modules ---
 const renderer = new ChatRenderer(chatArea, vscode);
+const activeLoadingKeys = new Set<string>();
+let hasPendingSubmission = false;
 
 const slashMenu = new SlashMenu(slashMenuEl, promptInput, (nextValue: string) => {
   promptInput.value = nextValue;
@@ -37,11 +39,17 @@ const slashMenu = new SlashMenu(slashMenuEl, promptInput, (nextValue: string) =>
 // --- Input handling ---
 
 function submitQuery(): void {
+  if (sendButton.disabled || promptInput.disabled) {
+    return;
+  }
+
   const text = promptInput.value.trim();
   if (!text) {
     return;
   }
 
+  hasPendingSubmission = true;
+  syncPromptBusy();
   vscode.postMessage({ command: 'submitQuery', text });
   promptInput.value = '';
   autoResizeInput();
@@ -51,6 +59,22 @@ function submitQuery(): void {
 function autoResizeInput(): void {
   promptInput.style.height = 'auto';
   promptInput.style.height = Math.min(promptInput.scrollHeight, 120) + 'px';
+}
+
+function setPromptBusy(isBusy: boolean): void {
+  promptInput.disabled = isBusy;
+  sendButton.disabled = isBusy;
+  promptInput.setAttribute('aria-disabled', String(isBusy));
+  sendButton.setAttribute('aria-disabled', String(isBusy));
+}
+
+function syncPromptBusy(): void {
+  setPromptBusy(hasPendingSubmission || activeLoadingKeys.size > 0);
+}
+
+function clearPendingSubmission(): void {
+  hasPendingSubmission = false;
+  syncPromptBusy();
 }
 
 // --- Event listeners ---
@@ -137,6 +161,7 @@ window.addEventListener('message', (event) => {
       break;
 
     case 'queryError':
+      clearPendingSubmission();
       renderer.renderError(
         message.source as string,
         message.message as string,
@@ -145,13 +170,23 @@ window.addEventListener('message', (event) => {
       break;
 
     case 'loading':
+      if (message.isLoading) {
+        hasPendingSubmission = false;
+        activeLoadingKeys.add(message.source as string);
+      } else {
+        activeLoadingKeys.delete(message.source as string);
+      }
+      syncPromptBusy();
       renderer.setLoading(
         message.source as string,
-        message.isLoading as boolean
+        message.isLoading as boolean,
+        message.text as string | undefined,
+        message.icon as string | undefined
       );
       break;
 
     case 'slashHelp':
+      clearPendingSubmission();
       renderer.renderSlashHelp(
         message.commandName as string,
         message.examples as string[]
@@ -159,13 +194,17 @@ window.addEventListener('message', (event) => {
       break;
 
     case 'clearChat':
+      clearPendingSubmission();
       renderer.clear();
       break;
 
     case 'assistantMessage':
+      clearPendingSubmission();
       renderer.renderAssistantMessage(
         message.text as string,
-        message.timestamp as string
+        message.timestamp as string,
+        message.kind as 'info' | 'ask' | 'chat' | undefined,
+        message.contextLabels as string[] | undefined
       );
       break;
 

--- a/src/webview/slashMenu.ts
+++ b/src/webview/slashMenu.ts
@@ -20,8 +20,8 @@ const SLASH_ITEMS: SlashMenuItem[] = [
   { command: '/onedrive', label: '/onedrive', description: 'Search OneDrive', icon: getSourceTextIcon('onedrive'), sourceIcon: 'onedrive' },
   { command: '/onenote', label: '/onenote', description: 'Search OneNote pages', icon: getSourceTextIcon('onenote'), sourceIcon: 'onenote' },
   { command: '/task', label: '/task', description: 'Search Planner and Microsoft To Do tasks', icon: getSourceTextIcon('todo'), sourceIcon: 'todo' },
-  { command: '/all', label: '/all', description: 'Search all sources', icon: getSourceTextIcon('all'), sourceIcon: 'all' },
-  { command: '/ask', label: '/ask', description: 'Ask Microsoft 365 Copilot using pinned snippets', icon: '🤖' },
+  { command: '/all', label: '/all', description: 'Search all sources explicitly', icon: getSourceTextIcon('all'), sourceIcon: 'all' },
+  { command: '/ask', label: '/ask', description: 'Ask Microsoft 365 Copilot using pinned snippets in the panel', icon: '🤖' },
   { command: '/clear', label: '/clear', description: 'Clear chat and discard pinned snippets', icon: '🧹' },
 ];
 


### PR DESCRIPTION
Plain text input previously searched all resources, so users could not have an unscoped Microsoft 365 Copilot conversation from ContextRelay. This change makes source search explicit through slash commands and uses plain input for Copilot chat.

## Summary

- Route non-slash input to a persisted Copilot conversation instead of `/all` search.
- Keep slash commands as the explicit source-search path, with `/ask` reusing the new contextual chat flow.
- Build bounded Copilot context payloads from pinned snippets and the latest search summary, including contextual file resources for suitable OneDrive/SharePoint URLs.
- Render Copilot replies in the ContextRelay panel with explicit Copy, Append, and Replace actions for editor updates.
- Show `Thinking...` with a brain icon during chat and disable the prompt controls while a request is in flight.
- Update docs and tests for routing, chat payloads, and context handling.

## Notes

Conversation continuity is preserved by the Copilot conversation ID. The previous assistant reply is not re-sent as `additionalContext`, which avoids duplicating conversation history. Explicit ContextRelay context is still shown in the panel when pinned snippets or the latest search summary are included.

## Validation

- `npm run compile`
- `npm run lint`
- `npm test` - 159 passing
- `npm run security:check` - 0 vulnerabilities

Closes #46