### PR TITLE
feat: add /workiq slash command for Work IQ API integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,12 +79,21 @@ The following delegated Microsoft Graph permissions are required by feature:
 | `People.Read.All` | Chat |
 | `OnlineMeetingTranscript.Read.All` | Chat |
 | `ExternalItem.Read.All` | Connectors search, Chat (optional) |
-| `WorkIQAgent.Ask` (on `api://workiq.svc.cloud.microsoft`) | `/workiq` command — Work IQ API (optional, requires Microsoft 365 Copilot license) |
 
 > **Important**:
 >
 > - Some permissions (for example `ChannelMessage.Read.All`, `OnlineMeetingTranscript.Read.All`, and `ExternalItem.Read.All`) require **tenant admin consent**.
 > - This extension still uses the built-in VS Code auth provider; it just avoids VS Code's default first-party client ID for Graph consent.
+
+#### Work IQ (non-Graph) permissions
+
+`WorkIQAgent.Ask` is **not** a Microsoft Graph permission. It is a delegated permission on a separate resource endpoint used only by the `/workiq` command:
+
+| Permission | Resource endpoint | Used by |
+|---|---|---|
+| `WorkIQAgent.Ask` | `api://workiq.svc.cloud.microsoft` | `/workiq` command — Work IQ API (optional, requires Microsoft 365 Copilot license) |
+
+> **Important**: This permission requires **tenant admin consent** and is only useful for users with a **Microsoft 365 Copilot license**. See [docs/work_iq.md](docs/work_iq.md) for setup instructions.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ ContextRelay is a VS Code extension that surfaces relevant Microsoft 365 context
 | `/task <query>` | Planner and Microsoft To Do tasks |
 | `/all <query>` | All enabled sources |
 | `/ask <instruction>` | Send pinned snippets to Microsoft 365 Copilot and show the reply in the panel |
+| `/workiq <query>` | Send a natural language query to Work IQ (A2A protocol) for Microsoft 365 work intelligence |
 | `/clear` | Clear the chat transcript and discard all pinned snippets |
 
 - **Snippet pinning** -- Save any search result as a named snippet, visible across sessions.
@@ -78,6 +79,7 @@ The following delegated Microsoft Graph permissions are required by feature:
 | `People.Read.All` | Chat |
 | `OnlineMeetingTranscript.Read.All` | Chat |
 | `ExternalItem.Read.All` | Connectors search, Chat (optional) |
+| `WorkIQAgent.Ask` (on `api://workiq.svc.cloud.microsoft`) | `/workiq` command — Work IQ API (optional, requires Microsoft 365 Copilot license) |
 
 > **Important**:
 >
@@ -573,6 +575,26 @@ Use `/ask` to let **Microsoft 365 Copilot** (not GitHub Copilot) process your cu
 If no snippets are pinned, `/ask` is aborted with a warning. Because this feature relies on the Microsoft 365 Copilot API (preview), you must have a Microsoft 365 Copilot license on the signed-in account and `contextRelay.enableChatPreview` enabled.
 
 To sign out, use the **Accounts** menu in VS Code.
+
+### `/workiq` — Query Work IQ for Microsoft 365 work intelligence
+
+Use `/workiq` to send natural language queries to the [Work IQ Gateway](https://learn.microsoft.com/en-us/microsoft-365/copilot/extensibility/work-iq-api-quickstart) via the A2A (Agent-to-Agent) v1.0 protocol. Work IQ provides AI-powered access to emails, meetings, files, and organizational knowledge.
+
+1. In the chat input, type `/workiq` followed by your question:
+
+   ```
+   /workiq Summarize my recent emails from Alice
+   /workiq What meetings do I have today?
+   /workiq Find documents about the Q3 budget review
+   ```
+
+2. ContextRelay sends the query to the Work IQ Gateway and displays the response in the panel.
+
+3. Consecutive `/workiq` queries maintain conversation context, so follow-up questions ("Tell me more about the 2 PM call") work naturally.
+
+> **Prerequisites**: The `/workiq` command requires a Microsoft 365 Copilot license and the `WorkIQAgent.Ask` delegated permission on your Entra app registration. See [docs/work_iq.md](docs/work_iq.md) for setup instructions.
+
+> **Note**: When `/workiq` is specified, all other slash commands in the input are ignored and treated as part of the query text.
 
 ---
 

--- a/docs/work_iq.md
+++ b/docs/work_iq.md
@@ -1,0 +1,106 @@
+# Work IQ Integration
+
+ContextRelay supports querying the [Work IQ Gateway](https://learn.microsoft.com/en-us/microsoft-365/copilot/extensibility/work-iq-api-quickstart) through the `/workiq` slash command. Work IQ is Microsoft's AI-native interface to Microsoft 365 work intelligence, allowing natural language queries over emails, meetings, files, and organizational knowledge.
+
+## Prerequisites
+
+- A user with a **Microsoft 365 Copilot license**
+- An [Entra app registration](../README.md#microsoft-entra-app-registration-setup-for-the-built-in-provider) configured in `contextRelay.auth.clientId`
+- The **Work IQ service principal** provisioned in your organization
+- The **`WorkIQAgent.Ask`** delegated permission added to your app registration with admin consent
+
+## Enable Work IQ API in your organization
+
+> ⏱️ ~5 minutes, one-time per organization.
+
+### Step 1: Create the Work IQ service principal
+
+The Work IQ service principal provisions the Work IQ resource in your tenant so users can request tokens for it.
+
+1. Go to [Graph Explorer](https://developer.microsoft.com/graph/graph-explorer) and sign in with a **tenant admin** account.
+2. Set the method to **POST** and the URL to `https://graph.microsoft.com/v1.0/servicePrincipals`.
+3. Select **Modify permissions** and consent to `Application.ReadWrite.All`.
+4. Enter the following in the **Request body**:
+
+   ```json
+   {
+     "appId": "fdcc1f02-fc51-4226-8753-f668596af7f7"
+   }
+   ```
+
+5. Select **Run query**. A **201 Created** response confirms success. A conflict error means the service principal already exists — proceed to the next step.
+
+### Step 2: Add the WorkIQAgent.Ask permission to your app registration
+
+1. Go to the [Microsoft Entra admin center](https://entra.microsoft.com).
+2. Navigate to **Entra ID** → **App registrations** → select your ContextRelay app registration (the one configured in `contextRelay.auth.clientId`).
+3. Select **API permissions** → **Add a permission** → **APIs my organization uses**.
+4. Search for **Work IQ** and select it.
+5. Select **Delegated permissions** → check **WorkIQAgent.Ask** → **Add permissions**.
+6. Select **Grant admin consent for [your tenant]** → confirm **Yes**.
+
+### Step 3: Verify
+
+After granting admin consent, the `WorkIQAgent.Ask` permission should appear with a green checkmark under **API permissions** in your app registration. Users with a Microsoft 365 Copilot license can now use the `/workiq` command in ContextRelay.
+
+> **Note**: If a user's Copilot license was recently assigned, the Work IQ index may take 15–30 minutes to build before queries return results.
+
+## Usage
+
+### Basic queries
+
+Type `/workiq` followed by your question in the ContextRelay chat panel:
+
+```
+/workiq Summarize my recent emails from Alice
+/workiq What meetings do I have today?
+/workiq Find documents about the Q3 budget review
+```
+
+### Multi-turn conversations
+
+Consecutive `/workiq` queries maintain conversation context via the A2A `contextId`. Follow-up questions work naturally:
+
+```
+/workiq What meetings do I have today?
+/workiq Tell me more about the 2 PM customer call
+```
+
+Use `/clear` to reset the conversation context and start fresh.
+
+### Slash command behavior
+
+When `/workiq` is specified, all other slash commands in the input are treated as part of the query text. For example:
+
+```
+/workiq /mail project update
+```
+
+This sends the entire text `/mail project update` as the query to Work IQ, rather than routing to the mail adapter.
+
+## How it works
+
+The `/workiq` command uses the [A2A (Agent-to-Agent) v1.0 protocol](https://a2a-protocol.org), an open standard for agent communication:
+
+- **Endpoint**: `https://workiq.svc.cloud.microsoft/a2a/`
+- **Protocol**: JSON-RPC 2.0 with `SendMessage` method
+- **Token audience**: `api://workiq.svc.cloud.microsoft`
+- **Version header**: `A2A-Version: 1.0`
+
+Work IQ uses the signed-in user's identity to access their Microsoft 365 data. The `Location` metadata (time zone) is included automatically so time-sensitive queries ("today", "this week") are grounded in the user's local time.
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---------|-----|
+| `401 Unauthorized` | Token audience mismatch. Ensure your app registration has the `WorkIQAgent.Ask` permission. |
+| `403 Forbidden` — no scope error | The user is missing a Microsoft 365 Copilot license. Assign the license and wait 15–30 minutes. |
+| `403 Forbidden` with scope error | Admin consent for `WorkIQAgent.Ask` was not granted. Ask your tenant admin to grant consent (Step 2 above). |
+| Empty response | The user's Copilot license may have been recently assigned. Wait 15–30 minutes for the index to build. |
+| `AADSTS65001: consent required` | Admin consent has not been granted. Complete Step 2 above. |
+
+## References
+
+- [Work IQ API Quickstart](https://learn.microsoft.com/en-us/microsoft-365/copilot/extensibility/work-iq-api-quickstart)
+- [Work IQ Samples on GitHub](https://github.com/microsoft/work-iq-samples)
+- [A2A Protocol Specification](https://a2a-protocol.org/latest/specification/)

--- a/docs/work_iq_ja.md
+++ b/docs/work_iq_ja.md
@@ -1,0 +1,106 @@
+# Work IQ 連携
+
+ContextRelay は `/workiq` スラッシュコマンドを通じて [Work IQ Gateway](https://learn.microsoft.com/ja-jp/microsoft-365/copilot/extensibility/work-iq-api-quickstart) への問い合わせをサポートします。Work IQ は Microsoft 365 のワークインテリジェンスへの AI ネイティブインターフェースであり、メール、会議、ファイル、組織のナレッジに対して自然言語でクエリを実行できます。
+
+## 前提条件
+
+- **Microsoft 365 Copilot ライセンス** を持つユーザー
+- `contextRelay.auth.clientId` に設定された [Entra アプリ登録](../README.md#microsoft-entra-app-registration-setup-for-the-built-in-provider)
+- 組織に **Work IQ サービスプリンシパル** がプロビジョニングされていること
+- アプリ登録に **`WorkIQAgent.Ask`** 委任されたアクセス許可が追加され、管理者の同意が付与されていること
+
+## 組織で Work IQ API を有効にする
+
+> ⏱️ 組織ごとに1回、約5分で完了します。
+
+### 手順 1: Work IQ サービスプリンシパルの作成
+
+Work IQ サービスプリンシパルは、ユーザーがトークンを要求できるようにテナントに Work IQ リソースをプロビジョニングします。
+
+1. [Graph Explorer](https://developer.microsoft.com/graph/graph-explorer) にアクセスし、**テナント管理者** アカウントでサインインします。
+2. メソッドを **POST** に設定し、URL を `https://graph.microsoft.com/v1.0/servicePrincipals` に設定します。
+3. **アクセス許可の変更** を選択し、`Application.ReadWrite.All` に同意します。
+4. **要求本文** に以下を入力します：
+
+   ```json
+   {
+     "appId": "fdcc1f02-fc51-4226-8753-f668596af7f7"
+   }
+   ```
+
+5. **クエリの実行** を選択します。**201 Created** レスポンスが表示されれば成功です。競合エラーはサービスプリンシパルが既に存在することを意味します — 次の手順に進んでください。
+
+### 手順 2: アプリ登録に WorkIQAgent.Ask アクセス許可を追加
+
+1. [Microsoft Entra 管理センター](https://entra.microsoft.com) にアクセスします。
+2. **Entra ID** → **アプリの登録** → ContextRelay アプリ登録（`contextRelay.auth.clientId` に設定されているもの）を選択します。
+3. **API のアクセス許可** → **アクセス許可の追加** → **自分の組織で使用している API** を選択します。
+4. **Work IQ** を検索して選択します。
+5. **委任されたアクセス許可** → **WorkIQAgent.Ask** にチェック → **アクセス許可の追加** を選択します。
+6. **[テナント名] に管理者の同意を与える** を選択 → **はい** で確認します。
+
+### 手順 3: 確認
+
+管理者の同意を付与した後、アプリ登録の **API のアクセス許可** に `WorkIQAgent.Ask` アクセス許可が緑色のチェックマーク付きで表示されるはずです。Microsoft 365 Copilot ライセンスを持つユーザーは、ContextRelay で `/workiq` コマンドを使用できるようになります。
+
+> **注意**: ユーザーの Copilot ライセンスが最近割り当てられた場合、Work IQ インデックスの構築に 15〜30 分かかることがあり、その間クエリ結果が返されない場合があります。
+
+## 使い方
+
+### 基本的なクエリ
+
+ContextRelay チャットパネルで `/workiq` の後に質問を入力します：
+
+```
+/workiq Alice からの最近のメールを要約して
+/workiq 今日のミーティングは何がありますか？
+/workiq Q3 予算レビューに関するドキュメントを探して
+```
+
+### マルチターン会話
+
+連続する `/workiq` クエリは A2A `contextId` を通じて会話コンテキストを維持します。フォローアップの質問が自然に機能します：
+
+```
+/workiq 今日のミーティングは何がありますか？
+/workiq 14時のお客様ミーティングについてもっと教えて
+```
+
+会話コンテキストをリセットしてやり直すには `/clear` を使用してください。
+
+### スラッシュコマンドの動作
+
+`/workiq` を指定すると、入力中の他のすべてのスラッシュコマンドはクエリテキストの一部として扱われます。例：
+
+```
+/workiq /mail プロジェクト更新
+```
+
+これはメールアダプターにルーティングするのではなく、テキスト全体 `/mail プロジェクト更新` をクエリとして Work IQ に送信します。
+
+## 仕組み
+
+`/workiq` コマンドは [A2A (Agent-to-Agent) v1.0 プロトコル](https://a2a-protocol.org)（エージェント間通信のオープン標準）を使用します：
+
+- **エンドポイント**: `https://workiq.svc.cloud.microsoft/a2a/`
+- **プロトコル**: JSON-RPC 2.0、`SendMessage` メソッド
+- **トークンオーディエンス**: `api://workiq.svc.cloud.microsoft`
+- **バージョンヘッダー**: `A2A-Version: 1.0`
+
+Work IQ はサインインしたユーザーの ID を使用して Microsoft 365 データにアクセスします。`Location` メタデータ（タイムゾーン）は自動的に含まれるため、時間に関するクエリ（「今日」「今週」）はユーザーのローカル時間に基づいて処理されます。
+
+## トラブルシューティング
+
+| 症状 | 対処法 |
+|------|--------|
+| `401 Unauthorized` | トークンオーディエンスの不一致。アプリ登録に `WorkIQAgent.Ask` アクセス許可があることを確認してください。 |
+| `403 Forbidden`（スコープエラーなし） | ユーザーに Microsoft 365 Copilot ライセンスがありません。ライセンスを割り当て、15〜30 分待ってください。 |
+| `403 Forbidden`（スコープエラーあり） | `WorkIQAgent.Ask` の管理者の同意が付与されていません。テナント管理者に同意の付与を依頼してください（上記手順 2）。 |
+| 空のレスポンス | ユーザーの Copilot ライセンスが最近割り当てられた可能性があります。インデックスの構築に 15〜30 分待ってください。 |
+| `AADSTS65001: consent required` | 管理者の同意が付与されていません。上記手順 2 を完了してください。 |
+
+## 参考情報
+
+- [Work IQ API クイックスタート](https://learn.microsoft.com/ja-jp/microsoft-365/copilot/extensibility/work-iq-api-quickstart)
+- [Work IQ サンプル (GitHub)](https://github.com/microsoft/work-iq-samples)
+- [A2A プロトコル仕様](https://a2a-protocol.org/latest/specification/)

--- a/package.json
+++ b/package.json
@@ -219,6 +219,11 @@
           "default": false,
           "description": "Enable Graph API debug logging in the ContextRelay Debug output channel"
         },
+        "contextRelay.enableWorkIqDebugLogging": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enable Work IQ API debug logging in the ContextRelay Debug output channel"
+        },
         "contextRelay.adapters.mail": {
           "type": "boolean",
           "default": true,

--- a/src/adapters/workIqAdapter.ts
+++ b/src/adapters/workIqAdapter.ts
@@ -1,0 +1,274 @@
+import * as crypto from 'crypto';
+import { GraphLogger } from './graphClient';
+
+const WORKIQ_ENDPOINT = 'https://workiq.svc.cloud.microsoft/a2a/';
+const A2A_VERSION = '1.0';
+
+let _logger: GraphLogger | undefined;
+
+export function setWorkIqLogger(logger: GraphLogger | undefined): void {
+  _logger = logger;
+}
+
+export interface WorkIqResponse {
+  text: string;
+  contextId?: string;
+  taskId?: string;
+  state?: string;
+}
+
+/**
+ * Resolve the IANA time zone and UTC offset for the `Location` metadata
+ * required by Work IQ to ground time-sensitive queries.
+ */
+export function resolveLocationMetadata(): { timeZoneOffset: number; timeZone: string } {
+  try {
+    const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    const offsetMinutes = -new Date().getTimezoneOffset();
+    return {
+      timeZoneOffset: offsetMinutes,
+      timeZone: timeZone && timeZone.length > 0 ? timeZone : 'UTC'
+    };
+  } catch {
+    return { timeZoneOffset: 0, timeZone: 'UTC' };
+  }
+}
+
+/**
+ * Build a JSON-RPC 2.0 request body for the A2A v1.0 `SendMessage` method.
+ */
+export function buildSendMessageRequest(
+  text: string,
+  contextId?: string
+): { body: string; requestId: string } {
+  const requestId = crypto.randomUUID();
+  const messageId = crypto.randomUUID();
+  const location = resolveLocationMetadata();
+
+  const message: Record<string, unknown> = {
+    role: 'ROLE_USER',
+    messageId,
+    parts: [{ text }],
+    metadata: {
+      Location: location
+    }
+  };
+
+  if (contextId) {
+    message.contextId = contextId;
+  }
+
+  const envelope = {
+    jsonrpc: '2.0',
+    id: requestId,
+    method: 'SendMessage',
+    params: { message }
+  };
+
+  return { body: JSON.stringify(envelope), requestId };
+}
+
+/**
+ * Extract the agent reply text from an A2A v1.0 JSON-RPC response.
+ *
+ * The response shape is:
+ * ```json
+ * { "result": { "task": { "artifacts": [{ "parts": [{ "text": "..." }] }] } } }
+ * ```
+ */
+export function extractResponseText(result: Record<string, unknown>): string {
+  const task = result.task as Record<string, unknown> | undefined;
+  if (!task) {
+    return '';
+  }
+
+  const artifacts = task.artifacts as Array<Record<string, unknown>> | undefined;
+  if (!Array.isArray(artifacts) || artifacts.length === 0) {
+    return '';
+  }
+
+  const textParts: string[] = [];
+  for (const artifact of artifacts) {
+    const parts = artifact.parts as Array<Record<string, unknown>> | undefined;
+    if (!Array.isArray(parts)) {
+      continue;
+    }
+    for (const part of parts) {
+      if (typeof part.text === 'string' && part.text.trim().length > 0) {
+        textParts.push(part.text);
+      }
+    }
+  }
+
+  return textParts.join('\n\n');
+}
+
+/**
+ * Extract the contextId from an A2A v1.0 response for multi-turn conversations.
+ */
+export function extractContextId(result: Record<string, unknown>): string | undefined {
+  for (const key of ['task', 'message']) {
+    const inner = result[key] as Record<string, unknown> | undefined;
+    if (inner && typeof inner.contextId === 'string') {
+      return inner.contextId;
+    }
+  }
+
+  if (typeof result.contextId === 'string') {
+    return result.contextId;
+  }
+
+  return undefined;
+}
+
+/**
+ * Extract the task state from an A2A v1.0 response.
+ */
+export function extractTaskState(result: Record<string, unknown>): string | undefined {
+  const task = result.task as Record<string, unknown> | undefined;
+  if (!task) {
+    return undefined;
+  }
+
+  const status = task.status as Record<string, unknown> | undefined;
+  return typeof status?.state === 'string' ? status.state : undefined;
+}
+
+async function workIqFetch(
+  token: string,
+  body: string
+): Promise<Response> {
+  _logger?.log(`→ POST ${WORKIQ_ENDPOINT}`);
+
+  const response = await fetch(WORKIQ_ENDPOINT, {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${token}`,
+      'Content-Type': 'application/json',
+      'Accept': 'application/json',
+      'A2A-Version': A2A_VERSION
+    },
+    body
+  });
+
+  _logger?.log(`← ${response.status} ${response.statusText} ${WORKIQ_ENDPOINT}`);
+
+  return response;
+}
+
+/**
+ * Send a message to the Work IQ Gateway and return the response.
+ * Only retries on 429/503 (safe to retry). Does not retry other errors
+ * to avoid duplicating prompts.
+ */
+export async function sendWorkIqMessage(
+  token: string,
+  text: string,
+  contextId?: string,
+  maxRetries = 2
+): Promise<WorkIqResponse> {
+  const { body } = buildSendMessageRequest(text, contextId);
+  let lastError: Error | undefined;
+  let delay = 1000;
+
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    let response: Response;
+    try {
+      response = await workIqFetch(token, body);
+    } catch (err) {
+      lastError = err instanceof Error ? err : new Error(String(err));
+      if (attempt < maxRetries) {
+        _logger?.log(`⚠ Network error, retry ${attempt + 1}/${maxRetries} after ${delay}ms`);
+        await sleep(delay);
+        delay = Math.min(delay * 2, 30000);
+        continue;
+      }
+      throw lastError;
+    }
+
+    if (response.status === 429 || response.status === 503) {
+      if (attempt < maxRetries) {
+        const retryAfterHeader = response.headers.get('Retry-After');
+        const retryDelay = retryAfterHeader
+          ? parseInt(retryAfterHeader, 10) * 1000
+          : delay;
+        _logger?.log(`⚠ Throttled (${response.status}), retry ${attempt + 1}/${maxRetries} after ${retryDelay}ms`);
+        await sleep(Math.min(retryDelay, 30000));
+        delay = Math.min(delay * 2, 30000);
+        continue;
+      }
+    }
+
+    if (!response.ok) {
+      const status = response.status;
+      let errorBody = '';
+      try {
+        errorBody = await response.text();
+      } catch {
+        // ignore
+      }
+
+      if (status === 401) {
+        throw Object.assign(
+          new Error('Unauthorized: Work IQ session expired, please re-authenticate.'),
+          { code: 401 }
+        );
+      }
+      if (status === 403) {
+        throw Object.assign(
+          new Error(
+            'Forbidden (403): Missing WorkIQAgent.Ask permission or Microsoft 365 Copilot license. ' +
+            'Ensure admin consent has been granted and the user has a Copilot license.'
+          ),
+          { code: 403 }
+        );
+      }
+
+      throw new Error(`Work IQ API error ${status}: ${errorBody}`);
+    }
+
+    const responseText = await response.text();
+    if (!responseText.trim()) {
+      throw new Error('Work IQ returned an empty response body.');
+    }
+
+    const parsed = JSON.parse(responseText) as Record<string, unknown>;
+
+    // Check for JSON-RPC error (can come in a 200 response)
+    if (parsed.error) {
+      const err = parsed.error as Record<string, unknown>;
+      const code = err.code ?? 'unknown';
+      const message = typeof err.message === 'string' ? err.message : JSON.stringify(err);
+      throw new Error(`Work IQ JSON-RPC error (${code}): ${message}`);
+    }
+
+    const result = parsed.result as Record<string, unknown> | undefined;
+    if (!result) {
+      throw new Error('Work IQ response missing result field.');
+    }
+
+    const taskState = extractTaskState(result);
+    if (taskState === 'TASK_STATE_FAILED') {
+      throw new Error('Work IQ task failed. The agent could not process the request.');
+    }
+
+    const text_response = extractResponseText(result);
+    const newContextId = extractContextId(result);
+    const task = result.task as Record<string, unknown> | undefined;
+
+    return {
+      text: text_response,
+      contextId: newContextId,
+      taskId: typeof task?.id === 'string' ? task.id : undefined,
+      state: taskState
+    };
+  }
+
+  throw lastError ?? new Error('Work IQ: max retries exceeded.');
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+export { WORKIQ_ENDPOINT, A2A_VERSION };

--- a/src/adapters/workIqAdapter.ts
+++ b/src/adapters/workIqAdapter.ts
@@ -256,10 +256,9 @@ export async function sendWorkIqMessage(
 
     if (!response.ok) {
       const status = response.status;
-      let errorBody = '';
       try {
-        errorBody = await response.text();
-        logWorkIqResponseBody(errorBody);
+        // Discard the body without reading it to avoid logging sensitive content.
+        await response.body?.cancel();
       } catch {
         // ignore
       }
@@ -280,11 +279,15 @@ export async function sendWorkIqMessage(
         );
       }
 
-      throw new Error(`Work IQ API error ${status}: ${errorBody}`);
+      const requestId = response.headers.get('x-ms-request-id')
+        ?? response.headers.get('request-id')
+        ?? response.headers.get('x-request-id')
+        ?? response.headers.get('traceparent');
+      const requestIdSuffix = requestId ? ` (Request ID: ${requestId})` : '';
+      throw new Error(`Work IQ API error ${status}${requestIdSuffix}`);
     }
 
     const responseText = await response.text();
-    logWorkIqResponseBody(responseText);
     if (!responseText.trim()) {
       throw new Error('Work IQ returned an empty response body.');
     }
@@ -321,11 +324,21 @@ export async function sendWorkIqMessage(
 
     const newContextId = extractContextId(result);
     const task = result.task as Record<string, unknown> | undefined;
+    const taskId = typeof task?.id === 'string' ? task.id : undefined;
+
+    // Log only structural metadata — no body content to avoid leaking M365 data.
+    if (_logger) {
+      const metaParts = ['↳ Work IQ response:'];
+      if (taskState) { metaParts.push(`state=${taskState}`); }
+      if (taskId) { metaParts.push(`taskId=${taskId}`); }
+      if (newContextId) { metaParts.push(`contextId=${newContextId}`); }
+      _logger.log(metaParts.join(' '));
+    }
 
     return {
       text: textResponse,
       contextId: newContextId,
-      taskId: typeof task?.id === 'string' ? task.id : undefined,
+      taskId,
       state: taskState
     };
   }
@@ -353,26 +366,6 @@ export function resolveRetryDelayMs(retryAfterHeader: string | null, fallbackMs:
 
 function sleep(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
-}
-
-function logWorkIqResponseBody(body: string): void {
-  if (!_logger || !body) {
-    return;
-  }
-
-  const formattedBody = formatWorkIqBodyForLogging(body);
-  _logger.log('↳ Work IQ response body:');
-  for (const line of formattedBody.split('\n')) {
-    _logger.log(`  ${line}`);
-  }
-}
-
-function formatWorkIqBodyForLogging(body: string): string {
-  try {
-    return JSON.stringify(JSON.parse(body), null, 2);
-  } catch {
-    return body;
-  }
 }
 
 export { WORKIQ_ENDPOINT, A2A_VERSION };

--- a/src/adapters/workIqAdapter.ts
+++ b/src/adapters/workIqAdapter.ts
@@ -204,6 +204,7 @@ export async function sendWorkIqMessage(
       let errorBody = '';
       try {
         errorBody = await response.text();
+        logWorkIqResponseBody(errorBody);
       } catch {
         // ignore
       }
@@ -228,6 +229,7 @@ export async function sendWorkIqMessage(
     }
 
     const responseText = await response.text();
+    logWorkIqResponseBody(responseText);
     if (!responseText.trim()) {
       throw new Error('Work IQ returned an empty response body.');
     }
@@ -296,6 +298,26 @@ export function resolveRetryDelayMs(retryAfterHeader: string | null, fallbackMs:
 
 function sleep(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function logWorkIqResponseBody(body: string): void {
+  if (!_logger || !body) {
+    return;
+  }
+
+  const formattedBody = formatWorkIqBodyForLogging(body);
+  _logger.log('↳ Work IQ response body:');
+  for (const line of formattedBody.split('\n')) {
+    _logger.log(`  ${line}`);
+  }
+}
+
+function formatWorkIqBodyForLogging(body: string): string {
+  try {
+    return JSON.stringify(JSON.parse(body), null, 2);
+  } catch {
+    return body;
+  }
 }
 
 export { WORKIQ_ENDPOINT, A2A_VERSION };

--- a/src/adapters/workIqAdapter.ts
+++ b/src/adapters/workIqAdapter.ts
@@ -75,32 +75,42 @@ export function buildSendMessageRequest(
  * ```json
  * { "result": { "task": { "artifacts": [{ "parts": [{ "text": "..." }] }] } } }
  * ```
+ * Some A2A implementations can also return a direct message payload:
+ * `{ "result": { "message": { "parts": [{ "text": "..." }] } } }`.
  */
 export function extractResponseText(result: Record<string, unknown>): string {
   const task = result.task as Record<string, unknown> | undefined;
-  if (!task) {
-    return '';
-  }
+  if (task) {
+    const artifacts = task.artifacts as Array<Record<string, unknown>> | undefined;
+    if (Array.isArray(artifacts) && artifacts.length > 0) {
+      const artifactTexts = artifacts
+        .map(artifact => extractPartsText(artifact))
+        .filter(text => text.trim().length > 0);
 
-  const artifacts = task.artifacts as Array<Record<string, unknown>> | undefined;
-  if (!Array.isArray(artifacts) || artifacts.length === 0) {
-    return '';
-  }
-
-  const textParts: string[] = [];
-  for (const artifact of artifacts) {
-    const parts = artifact.parts as Array<Record<string, unknown>> | undefined;
-    if (!Array.isArray(parts)) {
-      continue;
-    }
-    for (const part of parts) {
-      if (typeof part.text === 'string' && part.text.trim().length > 0) {
-        textParts.push(part.text);
+      if (artifactTexts.length > 0) {
+        return artifactTexts.join('\n\n');
       }
     }
   }
 
-  return textParts.join('\n\n');
+  const message = result.message as Record<string, unknown> | undefined;
+  if (message) {
+    return extractPartsText(message);
+  }
+
+  return '';
+}
+
+function extractPartsText(container: Record<string, unknown>): string {
+  const parts = container.parts as Array<Record<string, unknown>> | undefined;
+  if (!Array.isArray(parts)) {
+    return '';
+  }
+
+  return parts
+    .map(part => typeof part.text === 'string' ? part.text : '')
+    .filter(text => text.trim().length > 0)
+    .join('');
 }
 
 /**
@@ -168,30 +178,15 @@ export async function sendWorkIqMessage(
   maxRetries = 2
 ): Promise<WorkIqResponse> {
   const { body } = buildSendMessageRequest(text, contextId);
-  let lastError: Error | undefined;
   let delay = 1000;
 
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
-    let response: Response;
-    try {
-      response = await workIqFetch(token, body);
-    } catch (err) {
-      lastError = err instanceof Error ? err : new Error(String(err));
-      if (attempt < maxRetries) {
-        _logger?.log(`⚠ Network error, retry ${attempt + 1}/${maxRetries} after ${delay}ms`);
-        await sleep(delay);
-        delay = Math.min(delay * 2, 30000);
-        continue;
-      }
-      throw lastError;
-    }
+    const response = await workIqFetch(token, body);
 
     if (response.status === 429 || response.status === 503) {
       if (attempt < maxRetries) {
         const retryAfterHeader = response.headers.get('Retry-After');
-        const retryDelay = retryAfterHeader
-          ? parseInt(retryAfterHeader, 10) * 1000
-          : delay;
+        const retryDelay = resolveRetryDelayMs(retryAfterHeader, delay);
         _logger?.log(`⚠ Throttled (${response.status}), retry ${attempt + 1}/${maxRetries} after ${retryDelay}ms`);
         await sleep(Math.min(retryDelay, 30000));
         delay = Math.min(delay * 2, 30000);
@@ -232,7 +227,12 @@ export async function sendWorkIqMessage(
       throw new Error('Work IQ returned an empty response body.');
     }
 
-    const parsed = JSON.parse(responseText) as Record<string, unknown>;
+    let parsed: Record<string, unknown>;
+    try {
+      parsed = JSON.parse(responseText) as Record<string, unknown>;
+    } catch {
+      throw new Error('Work IQ returned an invalid JSON response.');
+    }
 
     // Check for JSON-RPC error (can come in a 200 response)
     if (parsed.error) {
@@ -252,19 +252,41 @@ export async function sendWorkIqMessage(
       throw new Error('Work IQ task failed. The agent could not process the request.');
     }
 
-    const text_response = extractResponseText(result);
+    const textResponse = extractResponseText(result);
+    if (taskState && taskState !== 'TASK_STATE_COMPLETED' && !textResponse.trim()) {
+      throw new Error(`Work IQ task did not complete (state: ${taskState}).`);
+    }
+
     const newContextId = extractContextId(result);
     const task = result.task as Record<string, unknown> | undefined;
 
     return {
-      text: text_response,
+      text: textResponse,
       contextId: newContextId,
       taskId: typeof task?.id === 'string' ? task.id : undefined,
       state: taskState
     };
   }
 
-  throw lastError ?? new Error('Work IQ: max retries exceeded.');
+  throw new Error('Work IQ: max retries exceeded.');
+}
+
+export function resolveRetryDelayMs(retryAfterHeader: string | null, fallbackMs: number): number {
+  if (!retryAfterHeader?.trim()) {
+    return fallbackMs;
+  }
+
+  const retryAfterSeconds = Number.parseInt(retryAfterHeader, 10);
+  if (Number.isFinite(retryAfterSeconds) && retryAfterSeconds >= 0) {
+    return retryAfterSeconds * 1000;
+  }
+
+  const retryAfterDate = Date.parse(retryAfterHeader);
+  if (Number.isFinite(retryAfterDate)) {
+    return Math.max(retryAfterDate - Date.now(), 0);
+  }
+
+  return fallbackMs;
 }
 
 function sleep(ms: number): Promise<void> {

--- a/src/adapters/workIqAdapter.ts
+++ b/src/adapters/workIqAdapter.ts
@@ -188,6 +188,7 @@ export async function sendWorkIqMessage(
         const retryAfterHeader = response.headers.get('Retry-After');
         const retryDelay = resolveRetryDelayMs(retryAfterHeader, delay);
         _logger?.log(`⚠ Throttled (${response.status}), retry ${attempt + 1}/${maxRetries} after ${retryDelay}ms`);
+        await response.body?.cancel();
         await sleep(Math.min(retryDelay, 30000));
         delay = Math.min(delay * 2, 30000);
         continue;

--- a/src/adapters/workIqAdapter.ts
+++ b/src/adapters/workIqAdapter.ts
@@ -188,7 +188,11 @@ export async function sendWorkIqMessage(
         const retryAfterHeader = response.headers.get('Retry-After');
         const retryDelay = resolveRetryDelayMs(retryAfterHeader, delay);
         _logger?.log(`⚠ Throttled (${response.status}), retry ${attempt + 1}/${maxRetries} after ${retryDelay}ms`);
-        await response.body?.cancel();
+        try {
+          await response.body?.cancel();
+        } catch {
+          // Ignore cleanup failures and keep the retry flow moving.
+        }
         await sleep(Math.min(retryDelay, 30000));
         delay = Math.min(delay * 2, 30000);
         continue;

--- a/src/adapters/workIqAdapter.ts
+++ b/src/adapters/workIqAdapter.ts
@@ -79,8 +79,14 @@ export function buildSendMessageRequest(
  * `{ "result": { "message": { "parts": [{ "text": "..." }] } } }`.
  */
 export function extractResponseText(result: Record<string, unknown>): string {
+  const candidates: string[] = [];
   const task = result.task as Record<string, unknown> | undefined;
   if (task) {
+    const statusMessage = extractTaskStatusMessageText(task);
+    if (statusMessage) {
+      candidates.push(statusMessage);
+    }
+
     const artifacts = task.artifacts as Array<Record<string, unknown>> | undefined;
     if (Array.isArray(artifacts) && artifacts.length > 0) {
       const artifactTexts = artifacts
@@ -88,17 +94,20 @@ export function extractResponseText(result: Record<string, unknown>): string {
         .filter(text => text.trim().length > 0);
 
       if (artifactTexts.length > 0) {
-        return artifactTexts.join('\n\n');
+        candidates.push(artifactTexts.join('\n\n'));
       }
     }
   }
 
   const message = result.message as Record<string, unknown> | undefined;
   if (message) {
-    return extractPartsText(message);
+    const messageText = extractPartsText(message);
+    if (messageText) {
+      candidates.push(messageText);
+    }
   }
 
-  return '';
+  return selectBestResponseText(candidates);
 }
 
 function extractPartsText(container: Record<string, unknown>): string {
@@ -111,6 +120,52 @@ function extractPartsText(container: Record<string, unknown>): string {
     .map(part => typeof part.text === 'string' ? part.text : '')
     .filter(text => text.trim().length > 0)
     .join('');
+}
+
+function extractTaskStatusMessageText(task: Record<string, unknown>): string {
+  const status = task.status as Record<string, unknown> | undefined;
+  const statusMessage = status?.message as Record<string, unknown> | undefined;
+  if (!statusMessage) {
+    return '';
+  }
+
+  return extractPartsText(statusMessage);
+}
+
+function selectBestResponseText(candidates: readonly string[]): string {
+  const meaningfulCandidates = candidates
+    .map(candidate => candidate.trim())
+    .filter(candidate => candidate.length > 0);
+
+  if (meaningfulCandidates.length === 0) {
+    return '';
+  }
+
+  meaningfulCandidates.sort((left, right) => scoreResponseText(right) - scoreResponseText(left));
+  return meaningfulCandidates[0];
+}
+
+function scoreResponseText(text: string): number {
+  const plainText = text.replace(/\s+/g, '');
+  if (plainText.length === 0) {
+    return 0;
+  }
+
+  let score = text.length;
+  if (/^[?？!！.。]+$/.test(plainText)) {
+    score -= 10_000;
+  }
+  if (/^#{1,3}\s/m.test(text)) {
+    score += 500;
+  }
+  if (/\[[^\]]+\]\(https?:\/\/[^)]+\)/.test(text)) {
+    score += 500;
+  }
+  if (/^[-*]\s/m.test(text) || /^\d+\.\s/m.test(text)) {
+    score += 250;
+  }
+
+  return score;
 }
 
 /**

--- a/src/auth/authProvider.ts
+++ b/src/auth/authProvider.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { buildProviderScopes, getBuiltInAuthConfigurationMessage } from './authScopes';
+import { buildProviderScopes, buildWorkIqProviderScopes, getBuiltInAuthConfigurationMessage } from './authScopes';
 
 const MAIL_SCOPES = ['Mail.Read'];
 const TEAMS_SCOPES = ['Chat.Read', 'ChannelMessage.Read.All'];
@@ -19,6 +19,7 @@ const CHAT_SCOPES = [
 
 export class AuthProvider {
   private session: vscode.AuthenticationSession | undefined;
+  private workIqSession: vscode.AuthenticationSession | undefined;
 
   constructor(_context: vscode.ExtensionContext) {}
 
@@ -102,6 +103,52 @@ export class AuthProvider {
     return session.accessToken;
   }
 
+  async getWorkIqSession(silent = false): Promise<vscode.AuthenticationSession | undefined> {
+    const config = vscode.workspace.getConfiguration('contextRelay');
+    const clientId = config.get<string>('auth.clientId')?.trim();
+    if (!clientId) {
+      if (silent) {
+        return undefined;
+      }
+      throw new Error(getBuiltInAuthConfigurationMessage());
+    }
+
+    const scopes = buildWorkIqProviderScopes({
+      clientId,
+      tenantId: config.get<string>('auth.tenantId', 'organizations')?.trim()
+    });
+
+    try {
+      this.workIqSession = await vscode.authentication.getSession('microsoft', scopes, {
+        createIfNone: !silent,
+        silent
+      });
+      return this.workIqSession;
+    } catch (err) {
+      this.workIqSession = undefined;
+
+      if (!silent) {
+        const message = err instanceof Error ? err.message : String(err);
+        if (message.includes('AADSTS65001')) {
+          throw new Error(
+            'Admin consent for WorkIQAgent.Ask has not been granted. ' +
+            'Ask your tenant admin to grant consent for the Work IQ permission on your app registration.'
+          );
+        }
+      }
+
+      return undefined;
+    }
+  }
+
+  async getWorkIqAccessToken(): Promise<string> {
+    const session = await this.getWorkIqSession();
+    if (!session) {
+      throw new Error('Not authenticated for Work IQ. Please sign in to use the /workiq command.');
+    }
+    return session.accessToken;
+  }
+
   async getAccountLabel(): Promise<string | undefined> {
     const session = await this.getSession(true);
     return session?.account?.label;
@@ -109,6 +156,7 @@ export class AuthProvider {
 
   clearSession(): void {
     this.session = undefined;
+    this.workIqSession = undefined;
   }
 
   onSessionChange(handler: () => void): vscode.Disposable {

--- a/src/auth/authScopes.ts
+++ b/src/auth/authScopes.ts
@@ -1,4 +1,6 @@
 const GRAPH_RESOURCE = 'https://graph.microsoft.com';
+const WORKIQ_RESOURCE = 'api://workiq.svc.cloud.microsoft';
+const WORKIQ_SCOPE = `${WORKIQ_RESOURCE}/WorkIQAgent.Ask`;
 const OIDC_SCOPES = ['offline_access', 'openid', 'profile'] as const;
 const DEFAULT_GRAPH_SCOPES = ['User.Read'];
 
@@ -44,4 +46,28 @@ export function getBuiltInAuthConfigurationMessage(): string {
   ].join(' ');
 }
 
-export { GRAPH_RESOURCE, OIDC_SCOPES };
+/**
+ * Build the scope array for Work IQ token acquisition.
+ * Work IQ uses a different resource (`api://workiq.svc.cloud.microsoft`) than
+ * Microsoft Graph, so it needs its own token request with only OIDC + Work IQ scopes.
+ */
+export function buildWorkIqProviderScopes(
+  options?: { clientId?: string; tenantId?: string }
+): string[] {
+  const scopes = new Set<string>();
+
+  OIDC_SCOPES.forEach(scope => scopes.add(scope));
+  scopes.add(WORKIQ_SCOPE);
+
+  if (options?.clientId?.trim()) {
+    scopes.add(`VSCODE_CLIENT_ID:${options.clientId.trim()}`);
+  }
+
+  if (options?.tenantId?.trim()) {
+    scopes.add(`VSCODE_TENANT:${options.tenantId.trim()}`);
+  }
+
+  return Array.from(scopes);
+}
+
+export { GRAPH_RESOURCE, OIDC_SCOPES, WORKIQ_RESOURCE, WORKIQ_SCOPE };

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,6 +14,7 @@ import {
 import { persistViewLocation, readStoredViewLocation } from './panel/viewLocationState';
 import { AuthProvider } from './auth/authProvider';
 import { setGraphLogger } from './adapters/graphClient';
+import { setWorkIqLogger } from './adapters/workIqAdapter';
 
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
   const GRAPH_DEBUG_LOGGING_CONFIG_KEY = 'enableGraphDebugLogging';
@@ -30,9 +31,11 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 
   const enableGraphDebugLogging = (): vscode.OutputChannel => {
     const channel = ensureDebugChannel();
-    setGraphLogger({
+    const logger = {
       log: (msg: string) => channel.appendLine(`[${new Date().toISOString()}] ${msg}`)
-    });
+    };
+    setGraphLogger(logger);
+    setWorkIqLogger(logger);
     return channel;
   };
 
@@ -41,9 +44,12 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       .getConfiguration('contextRelay')
       .get<boolean>(GRAPH_DEBUG_LOGGING_CONFIG_KEY, false);
 
-    setGraphLogger(isEnabled ? {
+    const logger = isEnabled ? {
       log: (msg: string) => ensureDebugChannel().appendLine(`[${new Date().toISOString()}] ${msg}`)
-    } : undefined);
+    } : undefined;
+
+    setGraphLogger(logger);
+    setWorkIqLogger(logger);
   };
 
   syncGraphDebugLogging();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -18,6 +18,7 @@ import { setWorkIqLogger } from './adapters/workIqAdapter';
 
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
   const GRAPH_DEBUG_LOGGING_CONFIG_KEY = 'enableGraphDebugLogging';
+  const WORKIQ_DEBUG_LOGGING_CONFIG_KEY = 'enableWorkIqDebugLogging';
   let debugChannel: vscode.OutputChannel | undefined;
 
   const ensureDebugChannel = (): vscode.OutputChannel => {
@@ -35,7 +36,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       log: (msg: string) => channel.appendLine(`[${new Date().toISOString()}] ${msg}`)
     };
     setGraphLogger(logger);
-    setWorkIqLogger(logger);
     return channel;
   };
 
@@ -49,14 +49,29 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     } : undefined;
 
     setGraphLogger(logger);
+  };
+
+  const syncWorkIqDebugLogging = (): void => {
+    const isEnabled = vscode.workspace
+      .getConfiguration('contextRelay')
+      .get<boolean>(WORKIQ_DEBUG_LOGGING_CONFIG_KEY, false);
+
+    const logger = isEnabled ? {
+      log: (msg: string) => ensureDebugChannel().appendLine(`[${new Date().toISOString()}] ${msg}`)
+    } : undefined;
+
     setWorkIqLogger(logger);
   };
 
   syncGraphDebugLogging();
+  syncWorkIqDebugLogging();
   context.subscriptions.push(
     vscode.workspace.onDidChangeConfiguration((event) => {
       if (event.affectsConfiguration(`contextRelay.${GRAPH_DEBUG_LOGGING_CONFIG_KEY}`)) {
         syncGraphDebugLogging();
+      }
+      if (event.affectsConfiguration(`contextRelay.${WORKIQ_DEBUG_LOGGING_CONFIG_KEY}`)) {
+        syncWorkIqDebugLogging();
       }
     })
   );

--- a/src/panel/chatViewProvider.ts
+++ b/src/panel/chatViewProvider.ts
@@ -948,6 +948,49 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
       white-space: pre-wrap;
     }
 
+    .message-text-rich {
+      white-space: normal;
+    }
+
+    .message-text-rich :first-child {
+      margin-top: 0;
+    }
+
+    .message-text-rich :last-child {
+      margin-bottom: 0;
+    }
+
+    .message-text-rich h1,
+    .message-text-rich h2,
+    .message-text-rich h3 {
+      line-height: 1.35;
+      margin: 0.9em 0 0.45em;
+    }
+
+    .message-text-rich p {
+      margin: 0.6em 0;
+    }
+
+    .message-text-rich ul,
+    .message-text-rich ol {
+      margin: 0.6em 0;
+      padding-left: 1.4em;
+    }
+
+    .message-text-rich li + li {
+      margin-top: 0.25em;
+    }
+
+    .message-text-rich a {
+      color: var(--vscode-textLink-foreground);
+    }
+
+    .message-text-rich hr {
+      border: 0;
+      border-top: 1px solid var(--vscode-panel-border);
+      margin: 0.9em 0;
+    }
+
     .context-used {
       margin-top: var(--cr-spacing-xs);
       font-size: 0.75em;

--- a/src/panel/chatViewProvider.ts
+++ b/src/panel/chatViewProvider.ts
@@ -8,6 +8,7 @@ import { searchPlanner } from '../adapters/plannerAdapter';
 import { searchRetrieval } from '../adapters/retrievalAdapter';
 import { searchTeams } from '../adapters/teamsAdapter';
 import { searchTodo } from '../adapters/todoAdapter';
+import { sendWorkIqMessage } from '../adapters/workIqAdapter';
 import { AuthProvider } from '../auth/authProvider';
 import { CacheStore } from '../cache/cacheStore';
 import { DocGenerator, type HandoffContext } from '../docs/docGenerator';
@@ -49,6 +50,7 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
   private static readonly MAX_TRANSCRIPT_LENGTH = 200;
   private transcript: HostToWebviewMessage[] = [];
   private currentConversationId?: string;
+  private currentWorkIqContextId?: string;
   private editorPanel?: vscode.WebviewPanel;
   private previewPanel?: vscode.WebviewPanel;
 
@@ -132,6 +134,7 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
     this.latestSearchSummary = undefined;
     this.latestVisibleResult = undefined;
     this.currentConversationId = undefined;
+    this.currentWorkIqContextId = undefined;
     this.postMessage({ command: 'clearChat' });
     this.sendPinnedItems();
   }
@@ -391,6 +394,11 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
       return;
     }
 
+    if (parsed.target === 'workiq') {
+      await this.handleWorkIqCommand(parsed.query);
+      return;
+    }
+
     if (parsed.target === 'chat') {
       await this.handlePlainChat(parsed.query);
       return;
@@ -515,6 +523,62 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
 
   private async handlePlainChat(prompt: string): Promise<void> {
     await this.handleCopilotChat(prompt, 'chat', false);
+  }
+
+  private async handleWorkIqCommand(query: string): Promise<void> {
+    this.postMessage({
+      command: 'loading',
+      source: 'all',
+      isLoading: true,
+      text: 'Asking Work IQ...',
+      icon: '🤖'
+    });
+
+    let token: string;
+    try {
+      token = await this.authProvider.getWorkIqAccessToken();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Work IQ authentication required.';
+      this.postMessage({
+        command: 'queryError',
+        source: 'all',
+        message,
+        timestamp: new Date().toISOString()
+      });
+      this.postMessage({ command: 'loading', source: 'all', isLoading: false });
+      return;
+    }
+
+    try {
+      const response = await sendWorkIqMessage(token, query, this.currentWorkIqContextId);
+
+      if (response.contextId) {
+        this.currentWorkIqContextId = response.contextId;
+      }
+
+      const text = response.text.trim();
+      if (!text) {
+        throw new Error('Work IQ returned an empty response.');
+      }
+
+      this.postMessage({
+        command: 'assistantMessage',
+        kind: 'chat',
+        text,
+        timestamp: new Date().toISOString()
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      vscode.window.showErrorMessage(`ContextRelay: Work IQ failed — ${message}`);
+      this.postMessage({
+        command: 'queryError',
+        source: 'all',
+        message,
+        timestamp: new Date().toISOString()
+      });
+    } finally {
+      this.postMessage({ command: 'loading', source: 'all', isLoading: false });
+    }
   }
 
   private async handleCopilotChat(

--- a/src/router/commandRouter.ts
+++ b/src/router/commandRouter.ts
@@ -11,7 +11,8 @@ export type RouteTarget =
   | 'task'
   | 'all'
   | 'ask'
-  | 'clear';
+  | 'clear'
+  | 'workiq';
 
 export type SearchCommandName = 'mail' | 'teams' | 'sharepoint' | 'onedrive' | 'onenote' | 'task' | 'all';
 export type SearchScope = 'all' | 'scoped' | 'operation';
@@ -40,7 +41,8 @@ const SEARCH_COMMAND_METADATA: Record<SearchCommandName, { target: RouteTarget; 
 
 const OPERATION_COMMANDS: Record<string, RouteTarget> = {
   ask: 'ask',
-  clear: 'clear'
+  clear: 'clear',
+  workiq: 'workiq'
 };
 
 function hasOwnKey<T extends object>(record: T, key: PropertyKey): key is keyof T {
@@ -71,7 +73,7 @@ export function parseCommand(input: string): ParsedCommand {
   if (hasOwnKey(OPERATION_COMMANDS, firstCommand)) {
     const rawQuery = commandMatch?.[2] ?? '';
     const target = OPERATION_COMMANDS[firstCommand];
-    const query = target === 'ask' ? rawQuery.trim() : '';
+    const query = target === 'ask' || target === 'workiq' ? rawQuery.trim() : '';
     const isEmpty = target === 'clear' ? false : query.length === 0;
 
     return {
@@ -186,7 +188,8 @@ export function getHelpText(command: string | readonly SearchCommandName[]): str
     task: 'Example: /task release checklist\nExample: /task metadata comments onboarding',
     all: 'Example: /all architecture decisions\nExample: /mail /onedrive architecture decisions\nPlain text without a slash command starts or continues a Microsoft 365 Copilot chat.',
     ask: 'Example: /ask 日本語に翻訳してmarkdownにして\nExample: /ask Summarize the pinned docs as a bullet list\nPinned snippets are used as context and the Microsoft 365 Copilot response is shown in the panel.',
-    clear: 'Example: /clear\nClears the current chat transcript and discards all pinned snippets.'
+    clear: 'Example: /clear\nClears the current chat transcript and discards all pinned snippets.',
+    workiq: 'Example: /workiq Summarize my recent emails from Alice\nExample: /workiq What meetings do I have today?\nSends a natural language query to the Work IQ Gateway (A2A protocol). Requires Microsoft 365 Copilot license.'
   };
   return examples[commandName] ?? 'Type a query to search Microsoft 365 content.';
 }

--- a/src/slashCommandIds.ts
+++ b/src/slashCommandIds.ts
@@ -1,0 +1,17 @@
+/**
+ * Canonical list of slash command IDs available in the ContextRelay slash menu.
+ * Kept as a pure data constant (no DOM dependencies) so it can be imported in
+ * both the webview (slashMenu.ts) and Node-based tests.
+ */
+export const SLASH_COMMAND_IDS: readonly string[] = [
+  '/mail',
+  '/teams',
+  '/sharepoint',
+  '/onedrive',
+  '/onenote',
+  '/task',
+  '/all',
+  '/ask',
+  '/workiq',
+  '/clear',
+];

--- a/src/test/suite/assistantMessageFormatting.test.ts
+++ b/src/test/suite/assistantMessageFormatting.test.ts
@@ -1,0 +1,26 @@
+import { strict as assert } from 'assert';
+import { formatAssistantMessageAsHtml, hasRichTextFormatting } from '../../webview/assistantMessageFormatting';
+
+suite('assistantMessageFormatting', () => {
+  test('detects markdown-like formatting in Work IQ responses', () => {
+    assert.equal(
+      hasRichTextFormatting('## Microsoft 365\n\n- admin\n- [Docs](https://example.com/docs)'),
+      true
+    );
+    assert.equal(hasRichTextFormatting('plain response text only'), false);
+  });
+
+  test('renders headings, lists, bold text, and links as safe html', () => {
+    const html = formatAssistantMessageAsHtml(
+      '## Microsoft 365\n\n- **admin** update\n- [品川](https://example.com/shinagawa)\n\n<script>alert(1)</script>'
+    );
+
+    assert.ok(html.includes('<h2>Microsoft 365</h2>'));
+    assert.ok(html.includes('<li><strong>admin</strong> update</li>'));
+    assert.ok(
+      html.includes('<a href="https://example.com/shinagawa" target="_blank" rel="noopener noreferrer">品川</a>')
+    );
+    assert.ok(html.includes('&lt;script&gt;alert(1)&lt;/script&gt;'));
+    assert.ok(!html.includes('<script>'));
+  });
+});

--- a/src/test/suite/chatViewProvider.test.ts
+++ b/src/test/suite/chatViewProvider.test.ts
@@ -16,7 +16,9 @@ const warningMessages: string[] = [];
 const errorMessages: string[] = [];
 const infoMessages: string[] = [];
 const capturedPayloads: Array<unknown> = [];
+const workIqRequests: Array<{ token: string; query: string; contextId?: string }> = [];
 let replies: string[] = [];
+let workIqReplies: Array<{ text: string; contextId?: string }> = [];
 
 class InMemoryMemento implements vscode.Memento {
   private readonly store = new Map<string, unknown>();
@@ -103,6 +105,15 @@ suite('ChatViewProvider', () => {
         };
       }
 
+      if (request === '../adapters/workIqAdapter') {
+        return {
+          sendWorkIqMessage: async (token: string, query: string, contextId?: string) => {
+            workIqRequests.push({ token, query, contextId });
+            return workIqReplies.shift() ?? { text: 'Work IQ answer', contextId: 'ctx-workiq-1' };
+          }
+        };
+      }
+
       if (request === '../adapters/handoffContentAdapter') {
         return {
           hydrateItemForHandoff: async (_token: string, item: unknown) => item
@@ -173,7 +184,12 @@ suite('ChatViewProvider', () => {
     errorMessages.length = 0;
     infoMessages.length = 0;
     capturedPayloads.length = 0;
+    workIqRequests.length = 0;
     replies = ['First answer', 'Second answer'];
+    workIqReplies = [
+      { text: 'Work IQ first answer', contextId: 'ctx-workiq-1' },
+      { text: 'Work IQ second answer', contextId: 'ctx-workiq-2' }
+    ];
   });
 
   test('includes the latest visible result in follow-up Copilot chat context', async () => {
@@ -231,5 +247,53 @@ suite('ChatViewProvider', () => {
     assert.equal(capturedPayloads.length, 0);
     assert.equal(errorMessages.length, 0);
     assert.equal(infoMessages.length, 0);
+  });
+
+  test('/workiq sends query, shows loading, and renders the Work IQ response', async () => {
+    const provider = new ChatViewProvider(
+      createContext(),
+      { getWorkIqAccessToken: async () => 'workiq-token' } as never,
+      {} as never
+    );
+    const messages: Array<{ command: string; [key: string]: unknown }> = [];
+    (provider as unknown as { postMessage(message: { command: string; [key: string]: unknown }): void }).postMessage = (message) => {
+      messages.push(message);
+    };
+
+    await provider.submitQuery('/workiq admin status');
+
+    assert.deepEqual(workIqRequests, [
+      { token: 'workiq-token', query: 'admin status', contextId: undefined }
+    ]);
+    assert.deepEqual(messages.map(message => message.command), [
+      'userMessage',
+      'loading',
+      'assistantMessage',
+      'loading'
+    ]);
+    assert.equal(messages[1].isLoading, true);
+    assert.equal(messages[1].text, 'Asking Work IQ...');
+    assert.equal(messages[2].text, 'Work IQ first answer');
+    assert.equal(messages[3].isLoading, false);
+  });
+
+  test('/workiq reuses contextId for follow-up queries and clearChat resets it', async () => {
+    const provider = new ChatViewProvider(
+      createContext(),
+      { getWorkIqAccessToken: async () => 'workiq-token' } as never,
+      {} as never
+    );
+    (provider as unknown as { postMessage(message: unknown): void }).postMessage = () => {};
+
+    await provider.submitQuery('/workiq Microsoft 365 admin status');
+    await provider.submitQuery('/workiq follow up');
+    provider.clearChat();
+    await provider.submitQuery('/workiq after clear');
+
+    assert.deepEqual(workIqRequests, [
+      { token: 'workiq-token', query: 'Microsoft 365 admin status', contextId: undefined },
+      { token: 'workiq-token', query: 'follow up', contextId: 'ctx-workiq-1' },
+      { token: 'workiq-token', query: 'after clear', contextId: undefined }
+    ]);
   });
 });

--- a/src/test/suite/commandRouter.test.ts
+++ b/src/test/suite/commandRouter.test.ts
@@ -225,4 +225,42 @@ suite('CommandRouter', () => {
     assert.ok(text.toLowerCase().includes('clear'));
     assert.ok(text.toLowerCase().includes('pinned'));
   });
+
+  test('/workiq command routes to workiq with query', () => {
+    const result = parseCommand('/workiq Summarize my recent emails');
+    assert.equal(result.target, 'workiq');
+    assert.equal(result.query, 'Summarize my recent emails');
+    assert.equal(result.isEmpty, false);
+    assert.deepEqual(result.targetSources, []);
+    assert.deepEqual(result.sourceCommands, []);
+    assert.equal(result.commandText, '/workiq');
+    assert.equal(result.searchScope, 'operation');
+  });
+
+  test('empty /workiq triggers isEmpty for slash help', () => {
+    const result = parseCommand('/workiq');
+    assert.equal(result.target, 'workiq');
+    assert.equal(result.isEmpty, true);
+    assert.equal(result.query, '');
+  });
+
+  test('/workiq ignores subsequent slash commands and treats them as query text', () => {
+    const result = parseCommand('/workiq /mail admin meeting notes');
+    assert.equal(result.target, 'workiq');
+    assert.equal(result.query, '/mail admin meeting notes');
+    assert.equal(result.isEmpty, false);
+  });
+
+  test('/workiq preserves Japanese query text', () => {
+    const result = parseCommand('/workiq 品川のミーティングについて教えて');
+    assert.equal(result.target, 'workiq');
+    assert.equal(result.query, '品川のミーティングについて教えて');
+    assert.equal(result.isEmpty, false);
+  });
+
+  test('getHelpText for workiq mentions Work IQ', () => {
+    const text = getHelpText('workiq');
+    assert.ok(text.toLowerCase().includes('work iq'));
+    assert.ok(text.includes('Example'));
+  });
 });

--- a/src/test/suite/manifestConsistency.test.ts
+++ b/src/test/suite/manifestConsistency.test.ts
@@ -78,6 +78,24 @@ suite('Extension manifest consistency', () => {
     );
   });
 
+  test('wires Work IQ logging to the ContextRelay debug channel', () => {
+    const extensionSourcePath = path.resolve(__dirname, '../../../../src/extension.ts');
+    const extensionSource = fs.readFileSync(extensionSourcePath, 'utf8');
+
+    assert.ok(
+      extensionSource.includes("import { setWorkIqLogger } from './adapters/workIqAdapter';"),
+      'extension activation must import the Work IQ logger hook'
+    );
+    assert.ok(
+      extensionSource.includes('setWorkIqLogger(logger);'),
+      'debug logging must enable Work IQ request/response status logs'
+    );
+    assert.ok(
+      extensionSource.includes('setWorkIqLogger(undefined);') || extensionSource.includes('setWorkIqLogger(logger);'),
+      'debug logging must be able to disable Work IQ logs with the shared logger state'
+    );
+  });
+
   test('contributes move-to-sidebar commands with icons for view/title menu', () => {
     const commands = packageJson.contributes?.commands ?? [];
 

--- a/src/test/suite/slashMenu.test.ts
+++ b/src/test/suite/slashMenu.test.ts
@@ -1,0 +1,23 @@
+import { strict as assert } from 'assert';
+import * as fs from 'fs';
+import * as path from 'path';
+
+suite('SlashMenu', () => {
+  test('includes /workiq in the slash command menu', () => {
+    const slashMenuSourcePath = path.resolve(__dirname, '../../../../src/webview/slashMenu.ts');
+    const slashMenuSource = fs.readFileSync(slashMenuSourcePath, 'utf8');
+
+    assert.ok(
+      slashMenuSource.includes("command: '/workiq'"),
+      '/workiq must be available in the slash menu'
+    );
+    assert.ok(
+      slashMenuSource.includes("label: '/workiq'"),
+      '/workiq must have a visible slash menu label'
+    );
+    assert.ok(
+      slashMenuSource.includes('Ask Work IQ'),
+      '/workiq must describe the Work IQ command in the slash menu'
+    );
+  });
+});

--- a/src/test/suite/slashMenu.test.ts
+++ b/src/test/suite/slashMenu.test.ts
@@ -1,23 +1,11 @@
 import { strict as assert } from 'assert';
-import * as fs from 'fs';
-import * as path from 'path';
+import { SLASH_COMMAND_IDS } from '../../slashCommandIds';
 
 suite('SlashMenu', () => {
   test('includes /workiq in the slash command menu', () => {
-    const slashMenuSourcePath = path.resolve(__dirname, '../../../../src/webview/slashMenu.ts');
-    const slashMenuSource = fs.readFileSync(slashMenuSourcePath, 'utf8');
-
     assert.ok(
-      slashMenuSource.includes("command: '/workiq'"),
+      SLASH_COMMAND_IDS.includes('/workiq'),
       '/workiq must be available in the slash menu'
-    );
-    assert.ok(
-      slashMenuSource.includes("label: '/workiq'"),
-      '/workiq must have a visible slash menu label'
-    );
-    assert.ok(
-      slashMenuSource.includes('Ask Work IQ'),
-      '/workiq must describe the Work IQ command in the slash menu'
     );
   });
 });

--- a/src/test/suite/workIqAdapter.test.ts
+++ b/src/test/suite/workIqAdapter.test.ts
@@ -254,7 +254,7 @@ suite('WorkIqAdapter', () => {
   });
 
   suite('sendWorkIqMessage', () => {
-    test('logs Work IQ request and response status without logging body text', async () => {
+    test('logs Work IQ request, response status, and response body', async () => {
       const originalFetch = globalThis.fetch;
       const messages: string[] = [];
       setWorkIqLogger({ log: (message: string) => messages.push(message) });
@@ -279,11 +279,45 @@ suite('WorkIqAdapter', () => {
       try {
         await sendWorkIqMessage('token', 'admin status');
 
-        assert.deepEqual(messages, [
-          '→ POST https://workiq.svc.cloud.microsoft/a2a/',
-          '← 200 OK https://workiq.svc.cloud.microsoft/a2a/'
-        ]);
-        assert.ok(messages.every(message => !message.includes('secret admin answer')));
+        assert.equal(messages[0], '→ POST https://workiq.svc.cloud.microsoft/a2a/');
+        assert.equal(messages[1], '← 200 OK https://workiq.svc.cloud.microsoft/a2a/');
+        assert.equal(messages[2], '↳ Work IQ response body:');
+        assert.ok(messages.some(message => message.includes('"jsonrpc": "2.0"')));
+        assert.ok(messages.some(message => message.includes('secret admin answer')));
+      } finally {
+        globalThis.fetch = originalFetch;
+        setWorkIqLogger(undefined);
+      }
+    });
+
+    test('logs HTTP error response bodies before throwing', async () => {
+      const originalFetch = globalThis.fetch;
+      const messages: string[] = [];
+      setWorkIqLogger({ log: (message: string) => messages.push(message) });
+      globalThis.fetch = (async (_input: Parameters<typeof fetch>[0], _init?: RequestInit): Promise<Response> =>
+        new Response(JSON.stringify({
+          error: {
+            code: 'Forbidden',
+            message: 'detailed workiq error'
+          }
+        }), {
+          status: 403,
+          statusText: 'Forbidden',
+          headers: { 'Content-Type': 'application/json' }
+        })
+      ) as typeof fetch;
+
+      try {
+        await assert.rejects(
+          () => sendWorkIqMessage('token', 'admin status'),
+          /Missing WorkIQAgent\.Ask permission or Microsoft 365 Copilot license/
+        );
+
+        assert.equal(messages[0], '→ POST https://workiq.svc.cloud.microsoft/a2a/');
+        assert.equal(messages[1], '← 403 Forbidden https://workiq.svc.cloud.microsoft/a2a/');
+        assert.equal(messages[2], '↳ Work IQ response body:');
+        assert.ok(messages.some(message => message.includes('"Forbidden"')));
+        assert.ok(messages.some(message => message.includes('detailed workiq error')));
       } finally {
         globalThis.fetch = originalFetch;
         setWorkIqLogger(undefined);

--- a/src/test/suite/workIqAdapter.test.ts
+++ b/src/test/suite/workIqAdapter.test.ts
@@ -4,7 +4,9 @@ import {
   extractResponseText,
   extractContextId,
   extractTaskState,
+  resolveRetryDelayMs,
   resolveLocationMetadata,
+  sendWorkIqMessage,
   WORKIQ_ENDPOINT,
   A2A_VERSION
 } from '../../adapters/workIqAdapter';
@@ -157,6 +159,20 @@ suite('WorkIqAdapter', () => {
       assert.ok(text.includes('廃止'));
       assert.ok(!text.startsWith('\n'));
     });
+
+    test('extracts text from direct message payload', () => {
+      const text = extractResponseText({
+        message: {
+          contextId: 'ctx-message-1',
+          parts: [
+            { text: 'Microsoft 365 admin summary: ' },
+            { text: '品川 office update.' }
+          ]
+        }
+      });
+
+      assert.equal(text, 'Microsoft 365 admin summary: 品川 office update.');
+    });
   });
 
   suite('extractContextId', () => {
@@ -233,6 +249,97 @@ suite('WorkIqAdapter', () => {
 
     test('A2A_VERSION is 1.0', () => {
       assert.equal(A2A_VERSION, '1.0');
+    });
+  });
+
+  suite('sendWorkIqMessage', () => {
+    test('does not retry network errors to avoid duplicate prompts', async () => {
+      const originalFetch = globalThis.fetch;
+      let calls = 0;
+      globalThis.fetch = (async () => {
+        calls++;
+        throw new Error('connection reset');
+      }) as typeof fetch;
+
+      try {
+        await assert.rejects(
+          () => sendWorkIqMessage('token', 'admin status', undefined, 2),
+          /connection reset/
+        );
+        assert.equal(calls, 1);
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
+
+    test('rejects invalid JSON responses without exposing response body', async () => {
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = (async (_input: Parameters<typeof fetch>[0], _init?: RequestInit): Promise<Response> =>
+        new Response('not json', {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' }
+        })
+      ) as typeof fetch;
+
+      try {
+        await assert.rejects(
+          () => sendWorkIqMessage('token', 'Microsoft 365 admin status'),
+          /invalid JSON response/
+        );
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
+
+    test('rejects non-complete task states without text', async () => {
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = (async (_input: Parameters<typeof fetch>[0], _init?: RequestInit): Promise<Response> =>
+        new Response(JSON.stringify({
+          jsonrpc: '2.0',
+          id: 'request-1',
+          result: {
+            task: {
+              id: 'task-1',
+              contextId: 'ctx-1',
+              status: { state: 'TASK_STATE_WORKING' },
+              artifacts: []
+            }
+          }
+        }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' }
+        })
+      ) as typeof fetch;
+
+      try {
+        await assert.rejects(
+          () => sendWorkIqMessage('token', '廃止されたサービスについて'),
+          /did not complete/
+        );
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
+  });
+
+  suite('resolveRetryDelayMs', () => {
+    test('uses fallback when Retry-After is missing', () => {
+      assert.equal(resolveRetryDelayMs(null, 1000), 1000);
+    });
+
+    test('parses Retry-After seconds', () => {
+      assert.equal(resolveRetryDelayMs('3', 1000), 3000);
+    });
+
+    test('uses fallback for malformed Retry-After headers', () => {
+      assert.equal(resolveRetryDelayMs('not-a-delay', 1000), 1000);
+    });
+
+    test('supports Retry-After HTTP-date values', () => {
+      const future = new Date(Date.now() + 5000).toUTCString();
+      const delay = resolveRetryDelayMs(future, 1000);
+      assert.ok(delay > 0);
+      assert.ok(delay <= 5000);
     });
   });
 

--- a/src/test/suite/workIqAdapter.test.ts
+++ b/src/test/suite/workIqAdapter.test.ts
@@ -281,7 +281,7 @@ suite('WorkIqAdapter', () => {
   });
 
   suite('sendWorkIqMessage', () => {
-    test('logs Work IQ request, response status, and response body', async () => {
+    test('logs Work IQ request, response status, and structural metadata', async () => {
       const originalFetch = globalThis.fetch;
       const messages: string[] = [];
       setWorkIqLogger({ log: (message: string) => messages.push(message) });
@@ -308,16 +308,17 @@ suite('WorkIqAdapter', () => {
 
         assert.equal(messages[0], '→ POST https://workiq.svc.cloud.microsoft/a2a/');
         assert.equal(messages[1], '← 200 OK https://workiq.svc.cloud.microsoft/a2a/');
-        assert.equal(messages[2], '↳ Work IQ response body:');
-        assert.ok(messages.some(message => message.includes('"jsonrpc": "2.0"')));
-        assert.ok(messages.some(message => message.includes('secret admin answer')));
+        assert.ok(messages.some(message => message.startsWith('↳ Work IQ response:')));
+        assert.ok(messages.some(message => message.includes('state=TASK_STATE_COMPLETED')));
+        assert.ok(messages.some(message => message.includes('taskId=task-1')));
+        assert.ok(!messages.some(message => message.includes('secret admin answer')), 'response body content must not appear in logs');
       } finally {
         globalThis.fetch = originalFetch;
         setWorkIqLogger(undefined);
       }
     });
 
-    test('logs HTTP error response bodies before throwing', async () => {
+    test('logs HTTP error status before throwing without logging response body', async () => {
       const originalFetch = globalThis.fetch;
       const messages: string[] = [];
       setWorkIqLogger({ log: (message: string) => messages.push(message) });
@@ -342,9 +343,8 @@ suite('WorkIqAdapter', () => {
 
         assert.equal(messages[0], '→ POST https://workiq.svc.cloud.microsoft/a2a/');
         assert.equal(messages[1], '← 403 Forbidden https://workiq.svc.cloud.microsoft/a2a/');
-        assert.equal(messages[2], '↳ Work IQ response body:');
-        assert.ok(messages.some(message => message.includes('"Forbidden"')));
-        assert.ok(messages.some(message => message.includes('detailed workiq error')));
+        assert.ok(!messages.some(message => message.includes('detailed workiq error')), 'error body must not appear in logs');
+        assert.ok(!messages.some(message => message.includes('↳ Work IQ response body:')), 'body log header must not appear');
       } finally {
         globalThis.fetch = originalFetch;
         setWorkIqLogger(undefined);

--- a/src/test/suite/workIqAdapter.test.ts
+++ b/src/test/suite/workIqAdapter.test.ts
@@ -1,0 +1,281 @@
+import { strict as assert } from 'assert';
+import {
+  buildSendMessageRequest,
+  extractResponseText,
+  extractContextId,
+  extractTaskState,
+  resolveLocationMetadata,
+  WORKIQ_ENDPOINT,
+  A2A_VERSION
+} from '../../adapters/workIqAdapter';
+import { buildWorkIqProviderScopes, WORKIQ_SCOPE } from '../../auth/authScopes';
+
+suite('WorkIqAdapter', () => {
+  suite('resolveLocationMetadata', () => {
+    test('returns timeZone and timeZoneOffset', () => {
+      const location = resolveLocationMetadata();
+      assert.ok(typeof location.timeZone === 'string');
+      assert.ok(location.timeZone.length > 0);
+      assert.ok(typeof location.timeZoneOffset === 'number');
+    });
+  });
+
+  suite('buildSendMessageRequest', () => {
+    test('builds valid JSON-RPC 2.0 envelope for admin query', () => {
+      const { body, requestId } = buildSendMessageRequest('admin permissions for Microsoft 365');
+      const parsed = JSON.parse(body);
+
+      assert.equal(parsed.jsonrpc, '2.0');
+      assert.equal(parsed.id, requestId);
+      assert.equal(parsed.method, 'SendMessage');
+      assert.ok(parsed.params);
+      assert.ok(parsed.params.message);
+    });
+
+    test('message has correct role and parts for Japanese query', () => {
+      const { body } = buildSendMessageRequest('品川オフィスの会議室を予約して');
+      const parsed = JSON.parse(body);
+      const message = parsed.params.message;
+
+      assert.equal(message.role, 'ROLE_USER');
+      assert.ok(Array.isArray(message.parts));
+      assert.equal(message.parts.length, 1);
+      assert.equal(message.parts[0].text, '品川オフィスの会議室を予約して');
+    });
+
+    test('message includes Location metadata', () => {
+      const { body } = buildSendMessageRequest('admin user list');
+      const parsed = JSON.parse(body);
+      const metadata = parsed.params.message.metadata;
+
+      assert.ok(metadata);
+      assert.ok(metadata.Location);
+      assert.ok(typeof metadata.Location.timeZone === 'string');
+      assert.ok(typeof metadata.Location.timeZoneOffset === 'number');
+    });
+
+    test('message has unique messageId', () => {
+      const { body: body1 } = buildSendMessageRequest('admin query 1');
+      const { body: body2 } = buildSendMessageRequest('admin query 2');
+      const msg1 = JSON.parse(body1).params.message;
+      const msg2 = JSON.parse(body2).params.message;
+
+      assert.notEqual(msg1.messageId, msg2.messageId);
+    });
+
+    test('includes contextId when provided for multi-turn', () => {
+      const { body } = buildSendMessageRequest('Microsoft 365 admin center', 'ctx-123');
+      const parsed = JSON.parse(body);
+      const message = parsed.params.message;
+
+      assert.equal(message.contextId, 'ctx-123');
+    });
+
+    test('omits contextId when not provided', () => {
+      const { body } = buildSendMessageRequest('廃止されたサービスについて教えて');
+      const parsed = JSON.parse(body);
+      const message = parsed.params.message;
+
+      assert.equal(message.contextId, undefined);
+    });
+
+    test('each request has a unique requestId', () => {
+      const result1 = buildSendMessageRequest('admin query');
+      const result2 = buildSendMessageRequest('admin query');
+
+      assert.notEqual(result1.requestId, result2.requestId);
+    });
+  });
+
+  suite('extractResponseText', () => {
+    test('extracts text from task artifacts for admin response', () => {
+      const result = {
+        task: {
+          id: 'task-1',
+          contextId: 'ctx-1',
+          status: { state: 'TASK_STATE_COMPLETED' },
+          artifacts: [
+            {
+              artifactId: 'art-1',
+              name: 'Answer',
+              parts: [
+                { text: 'The admin permissions for Microsoft 365 include Global Admin, User Admin, and Exchange Admin.' }
+              ]
+            }
+          ]
+        }
+      };
+
+      const text = extractResponseText(result);
+      assert.ok(text.includes('admin permissions'));
+      assert.ok(text.includes('Microsoft 365'));
+    });
+
+    test('extracts text from multiple artifacts', () => {
+      const result = {
+        task: {
+          id: 'task-1',
+          artifacts: [
+            { parts: [{ text: '品川のミーティングは3件あります。' }] },
+            { parts: [{ text: '次のミーティングは14:00からです。' }] }
+          ]
+        }
+      };
+
+      const text = extractResponseText(result);
+      assert.ok(text.includes('品川'));
+      assert.ok(text.includes('14:00'));
+    });
+
+    test('returns empty string when no task in result', () => {
+      const text = extractResponseText({});
+      assert.equal(text, '');
+    });
+
+    test('returns empty string when no artifacts in task', () => {
+      const text = extractResponseText({ task: { id: 'task-1' } });
+      assert.equal(text, '');
+    });
+
+    test('returns empty string when artifacts have no text parts', () => {
+      const text = extractResponseText({
+        task: {
+          artifacts: [{ parts: [{ url: 'https://example.com' }] }]
+        }
+      });
+      assert.equal(text, '');
+    });
+
+    test('skips empty text parts', () => {
+      const text = extractResponseText({
+        task: {
+          artifacts: [
+            { parts: [{ text: '' }, { text: '廃止されたサービスの一覧です。' }] }
+          ]
+        }
+      });
+      assert.ok(text.includes('廃止'));
+      assert.ok(!text.startsWith('\n'));
+    });
+  });
+
+  suite('extractContextId', () => {
+    test('extracts contextId from task', () => {
+      const contextId = extractContextId({
+        task: { id: 'task-1', contextId: 'ctx-admin-123' }
+      });
+      assert.equal(contextId, 'ctx-admin-123');
+    });
+
+    test('extracts contextId from message', () => {
+      const contextId = extractContextId({
+        message: { contextId: 'ctx-品川-456' }
+      });
+      assert.equal(contextId, 'ctx-品川-456');
+    });
+
+    test('extracts contextId from top-level result', () => {
+      const contextId = extractContextId({ contextId: 'ctx-789' });
+      assert.equal(contextId, 'ctx-789');
+    });
+
+    test('returns undefined when no contextId present', () => {
+      const contextId = extractContextId({ task: { id: 'task-1' } });
+      assert.equal(contextId, undefined);
+    });
+
+    test('prefers task contextId over top-level', () => {
+      const contextId = extractContextId({
+        task: { contextId: 'ctx-task' },
+        contextId: 'ctx-top'
+      });
+      assert.equal(contextId, 'ctx-task');
+    });
+  });
+
+  suite('extractTaskState', () => {
+    test('extracts TASK_STATE_COMPLETED', () => {
+      const state = extractTaskState({
+        task: { status: { state: 'TASK_STATE_COMPLETED' } }
+      });
+      assert.equal(state, 'TASK_STATE_COMPLETED');
+    });
+
+    test('extracts TASK_STATE_FAILED', () => {
+      const state = extractTaskState({
+        task: { status: { state: 'TASK_STATE_FAILED' } }
+      });
+      assert.equal(state, 'TASK_STATE_FAILED');
+    });
+
+    test('extracts TASK_STATE_WORKING', () => {
+      const state = extractTaskState({
+        task: { status: { state: 'TASK_STATE_WORKING' } }
+      });
+      assert.equal(state, 'TASK_STATE_WORKING');
+    });
+
+    test('returns undefined when no task', () => {
+      const state = extractTaskState({});
+      assert.equal(state, undefined);
+    });
+
+    test('returns undefined when no status', () => {
+      const state = extractTaskState({ task: { id: 'task-1' } });
+      assert.equal(state, undefined);
+    });
+  });
+
+  suite('constants', () => {
+    test('WORKIQ_ENDPOINT is the A2A gateway', () => {
+      assert.equal(WORKIQ_ENDPOINT, 'https://workiq.svc.cloud.microsoft/a2a/');
+    });
+
+    test('A2A_VERSION is 1.0', () => {
+      assert.equal(A2A_VERSION, '1.0');
+    });
+  });
+
+  suite('buildWorkIqProviderScopes', () => {
+    test('includes OIDC scopes and Work IQ scope', () => {
+      const scopes = buildWorkIqProviderScopes();
+      assert.ok(scopes.includes('offline_access'));
+      assert.ok(scopes.includes('openid'));
+      assert.ok(scopes.includes('profile'));
+      assert.ok(scopes.includes(WORKIQ_SCOPE));
+    });
+
+    test('does not include Graph scopes', () => {
+      const scopes = buildWorkIqProviderScopes();
+      const graphScopes = scopes.filter(s => s.includes('graph.microsoft.com'));
+      assert.equal(graphScopes.length, 0);
+    });
+
+    test('includes VSCODE_CLIENT_ID when provided', () => {
+      const scopes = buildWorkIqProviderScopes({ clientId: 'test-client-id' });
+      assert.ok(scopes.includes('VSCODE_CLIENT_ID:test-client-id'));
+    });
+
+    test('includes VSCODE_TENANT when provided', () => {
+      const scopes = buildWorkIqProviderScopes({ tenantId: 'test-tenant-id' });
+      assert.ok(scopes.includes('VSCODE_TENANT:test-tenant-id'));
+    });
+
+    test('trims whitespace from clientId and tenantId', () => {
+      const scopes = buildWorkIqProviderScopes({
+        clientId: '  my-client  ',
+        tenantId: '  my-tenant  '
+      });
+      assert.ok(scopes.includes('VSCODE_CLIENT_ID:my-client'));
+      assert.ok(scopes.includes('VSCODE_TENANT:my-tenant'));
+    });
+
+    test('skips empty clientId and tenantId', () => {
+      const scopes = buildWorkIqProviderScopes({ clientId: '  ', tenantId: '' });
+      const clientScopes = scopes.filter(s => s.startsWith('VSCODE_CLIENT_ID'));
+      const tenantScopes = scopes.filter(s => s.startsWith('VSCODE_TENANT'));
+      assert.equal(clientScopes.length, 0);
+      assert.equal(tenantScopes.length, 0);
+    });
+  });
+});

--- a/src/test/suite/workIqAdapter.test.ts
+++ b/src/test/suite/workIqAdapter.test.ts
@@ -174,6 +174,33 @@ suite('WorkIqAdapter', () => {
 
       assert.equal(text, 'Microsoft 365 admin summary: 品川 office update.');
     });
+
+    test('prefers task status message over placeholder artifact text', () => {
+      const text = extractResponseText({
+        task: {
+          contextId: 'ctx-1',
+          status: {
+            state: 'TASK_STATE_COMPLETED',
+            message: {
+              parts: [
+                {
+                  text: '## Microsoft 365\n\n- admin updates are available\n- 品川 schedule changes are included'
+                }
+              ]
+            }
+          },
+          artifacts: [
+            {
+              parts: [{ text: '？' }]
+            }
+          ]
+        }
+      });
+
+      assert.ok(text.includes('Microsoft 365'));
+      assert.ok(text.includes('品川'));
+      assert.notEqual(text, '？');
+    });
   });
 
   suite('extractContextId', () => {

--- a/src/test/suite/workIqAdapter.test.ts
+++ b/src/test/suite/workIqAdapter.test.ts
@@ -7,6 +7,7 @@ import {
   resolveRetryDelayMs,
   resolveLocationMetadata,
   sendWorkIqMessage,
+  setWorkIqLogger,
   WORKIQ_ENDPOINT,
   A2A_VERSION
 } from '../../adapters/workIqAdapter';
@@ -253,6 +254,42 @@ suite('WorkIqAdapter', () => {
   });
 
   suite('sendWorkIqMessage', () => {
+    test('logs Work IQ request and response status without logging body text', async () => {
+      const originalFetch = globalThis.fetch;
+      const messages: string[] = [];
+      setWorkIqLogger({ log: (message: string) => messages.push(message) });
+      globalThis.fetch = (async (_input: Parameters<typeof fetch>[0], _init?: RequestInit): Promise<Response> =>
+        new Response(JSON.stringify({
+          jsonrpc: '2.0',
+          id: 'request-1',
+          result: {
+            task: {
+              id: 'task-1',
+              status: { state: 'TASK_STATE_COMPLETED' },
+              artifacts: [{ parts: [{ text: 'secret admin answer' }] }]
+            }
+          }
+        }), {
+          status: 200,
+          statusText: 'OK',
+          headers: { 'Content-Type': 'application/json' }
+        })
+      ) as typeof fetch;
+
+      try {
+        await sendWorkIqMessage('token', 'admin status');
+
+        assert.deepEqual(messages, [
+          '→ POST https://workiq.svc.cloud.microsoft/a2a/',
+          '← 200 OK https://workiq.svc.cloud.microsoft/a2a/'
+        ]);
+        assert.ok(messages.every(message => !message.includes('secret admin answer')));
+      } finally {
+        globalThis.fetch = originalFetch;
+        setWorkIqLogger(undefined);
+      }
+    });
+
     test('parses successful JSON-RPC task response', async () => {
       const originalFetch = globalThis.fetch;
       globalThis.fetch = (async (_input: Parameters<typeof fetch>[0], _init?: RequestInit): Promise<Response> =>

--- a/src/test/suite/workIqAdapter.test.ts
+++ b/src/test/suite/workIqAdapter.test.ts
@@ -253,6 +253,145 @@ suite('WorkIqAdapter', () => {
   });
 
   suite('sendWorkIqMessage', () => {
+    test('parses successful JSON-RPC task response', async () => {
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = (async (_input: Parameters<typeof fetch>[0], _init?: RequestInit): Promise<Response> =>
+        new Response(JSON.stringify({
+          jsonrpc: '2.0',
+          id: 'request-1',
+          result: {
+            task: {
+              id: 'task-1',
+              contextId: 'ctx-1',
+              status: { state: 'TASK_STATE_COMPLETED' },
+              artifacts: [
+                { parts: [{ text: 'admin summary for Microsoft 365' }] }
+              ]
+            }
+          }
+        }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' }
+        })
+      ) as typeof fetch;
+
+      try {
+        const response = await sendWorkIqMessage('token', 'admin summary');
+        assert.equal(response.text, 'admin summary for Microsoft 365');
+        assert.equal(response.contextId, 'ctx-1');
+        assert.equal(response.taskId, 'task-1');
+        assert.equal(response.state, 'TASK_STATE_COMPLETED');
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
+
+    test('surfaces JSON-RPC errors from 200 responses', async () => {
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = (async (_input: Parameters<typeof fetch>[0], _init?: RequestInit): Promise<Response> =>
+        new Response(JSON.stringify({
+          jsonrpc: '2.0',
+          id: 'request-1',
+          error: {
+            code: -32601,
+            message: 'Method not found'
+          }
+        }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' }
+        })
+      ) as typeof fetch;
+
+      try {
+        await assert.rejects(
+          () => sendWorkIqMessage('token', 'admin status'),
+          /JSON-RPC error \(-32601\): Method not found/
+        );
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
+
+    test('maps 401 and 403 responses to actionable errors', async () => {
+      const originalFetch = globalThis.fetch;
+      let status = 401;
+      globalThis.fetch = (async (_input: Parameters<typeof fetch>[0], _init?: RequestInit): Promise<Response> =>
+        new Response('forbidden', {
+          status,
+          headers: { 'Content-Type': 'text/plain' }
+        })
+      ) as typeof fetch;
+
+      try {
+        await assert.rejects(
+          () => sendWorkIqMessage('token', 'admin status'),
+          /session expired/
+        );
+
+        status = 403;
+
+        await assert.rejects(
+          () => sendWorkIqMessage('token', 'admin status'),
+          /Missing WorkIQAgent\.Ask permission or Microsoft 365 Copilot license/
+        );
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
+
+    test('retries 429 responses and cancels the throttled response body', async () => {
+      const originalFetch = globalThis.fetch;
+      let calls = 0;
+      let cancelled = false;
+
+      const throttledBody = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode('throttled'));
+        },
+        cancel() {
+          cancelled = true;
+        }
+      });
+
+      globalThis.fetch = (async (_input: Parameters<typeof fetch>[0], _init?: RequestInit): Promise<Response> => {
+        calls++;
+
+        if (calls === 1) {
+          return new Response(throttledBody, {
+            status: 429,
+            headers: {
+              'Content-Type': 'text/plain',
+              'Retry-After': '0'
+            }
+          });
+        }
+
+        return new Response(JSON.stringify({
+          jsonrpc: '2.0',
+          id: 'request-2',
+          result: {
+            task: {
+              id: 'task-2',
+              status: { state: 'TASK_STATE_COMPLETED' },
+              artifacts: [{ parts: [{ text: '品川 meeting summary' }] }]
+            }
+          }
+        }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' }
+        });
+      }) as typeof fetch;
+
+      try {
+        const response = await sendWorkIqMessage('token', '品川', undefined, 1);
+        assert.equal(response.text, '品川 meeting summary');
+        assert.equal(calls, 2);
+        assert.equal(cancelled, true);
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
+
     test('does not retry network errors to avoid duplicate prompts', async () => {
       const originalFetch = globalThis.fetch;
       let calls = 0;

--- a/src/webview/assistantMessageFormatting.ts
+++ b/src/webview/assistantMessageFormatting.ts
@@ -1,0 +1,128 @@
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function escapeAttribute(value: string): string {
+  return escapeHtml(value);
+}
+
+function renderInlineMarkdown(text: string): string {
+  const linkPattern = /\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g;
+  let cursor = 0;
+  let html = '';
+
+  for (const match of text.matchAll(linkPattern)) {
+    const [fullMatch, label, url] = match;
+    const start = match.index ?? 0;
+    html += escapeHtml(text.slice(cursor, start));
+    html += `<a href="${escapeAttribute(url)}" target="_blank" rel="noopener noreferrer">${escapeHtml(label)}</a>`;
+    cursor = start + fullMatch.length;
+  }
+
+  html += escapeHtml(text.slice(cursor));
+  return html.replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>');
+}
+
+function renderParagraph(lines: string[]): string {
+  return `<p>${lines.map(renderInlineMarkdown).join('<br>')}</p>`;
+}
+
+function isUnorderedListItem(line: string): boolean {
+  return /^[-*]\s+/.test(line);
+}
+
+function isOrderedListItem(line: string): boolean {
+  return /^\d+\.\s+/.test(line);
+}
+
+function renderList(lines: string[], ordered: boolean): string {
+  const tagName = ordered ? 'ol' : 'ul';
+  const itemPattern = ordered ? /^\d+\.\s+/ : /^[-*]\s+/;
+  const items = lines
+    .map(line => line.replace(itemPattern, ''))
+    .map(item => `<li>${renderInlineMarkdown(item)}</li>`)
+    .join('');
+
+  return `<${tagName}>${items}</${tagName}>`;
+}
+
+export function hasRichTextFormatting(text: string): boolean {
+  return /(^|\n)#{1,3}\s|(^|\n)([-*]|\d+\.)\s|\*\*[^*]+\*\*|\[[^\]]+\]\(https?:\/\/[^\s)]+\)/m.test(text);
+}
+
+export function formatAssistantMessageAsHtml(text: string): string {
+  const normalizedText = text.replace(/\r\n/g, '\n').trim();
+  if (!normalizedText) {
+    return '';
+  }
+
+  const lines = normalizedText.split('\n');
+  const blocks: string[] = [];
+
+  for (let index = 0; index < lines.length;) {
+    const line = lines[index].trimEnd();
+
+    if (line.trim().length === 0) {
+      index += 1;
+      continue;
+    }
+
+    const headingMatch = /^(#{1,3})\s+(.*)$/.exec(line);
+    if (headingMatch) {
+      const level = headingMatch[1].length;
+      blocks.push(`<h${level}>${renderInlineMarkdown(headingMatch[2].trim())}</h${level}>`);
+      index += 1;
+      continue;
+    }
+
+    if (/^---+$/.test(line.trim())) {
+      blocks.push('<hr>');
+      index += 1;
+      continue;
+    }
+
+    if (isUnorderedListItem(line.trim())) {
+      const listLines: string[] = [];
+      while (index < lines.length && isUnorderedListItem(lines[index].trim())) {
+        listLines.push(lines[index].trim());
+        index += 1;
+      }
+      blocks.push(renderList(listLines, false));
+      continue;
+    }
+
+    if (isOrderedListItem(line.trim())) {
+      const listLines: string[] = [];
+      while (index < lines.length && isOrderedListItem(lines[index].trim())) {
+        listLines.push(lines[index].trim());
+        index += 1;
+      }
+      blocks.push(renderList(listLines, true));
+      continue;
+    }
+
+    const paragraphLines: string[] = [];
+    while (index < lines.length && lines[index].trim().length > 0) {
+      const currentLine = lines[index].trimEnd();
+      if (/^(#{1,3})\s+/.test(currentLine) || /^---+$/.test(currentLine.trim()) || isUnorderedListItem(currentLine.trim()) || isOrderedListItem(currentLine.trim())) {
+        break;
+      }
+      paragraphLines.push(currentLine);
+      index += 1;
+    }
+
+    if (paragraphLines.length > 0) {
+      blocks.push(renderParagraph(paragraphLines));
+      continue;
+    }
+
+    index += 1;
+  }
+
+  return blocks.join('');
+}

--- a/src/webview/chatRenderer.ts
+++ b/src/webview/chatRenderer.ts
@@ -1,12 +1,13 @@
 /**
  * Chat renderer for the ContextRelay webview.
  * Renders messages, results, loading indicators, and errors.
- * Dynamic result content is built with DOM APIs so untrusted data never flows
- * through HTML injection paths.
+ * Dynamic result content is built with DOM APIs, except for assistant messages
+ * where limited HTML is generated from escaped markdown-like text.
  */
 
 import { getSourceInlineSvg, getSourceLabel, getSourceTextIcon } from '../sourcePresentation';
 import { canOpenResult } from '../models/contextItem';
+import { formatAssistantMessageAsHtml, hasRichTextFormatting } from './assistantMessageFormatting';
 
 interface ContextItem {
   source: 'sharepoint' | 'onedrive' | 'mail' | 'teams' | 'onenote' | 'planner' | 'todo' | 'connectors';
@@ -144,7 +145,12 @@ export class ChatRenderer {
 
     const textDiv = document.createElement('div');
     textDiv.className = 'message-text';
-    textDiv.textContent = text;
+    if (hasRichTextFormatting(text)) {
+      textDiv.classList.add('message-text-rich');
+      textDiv.innerHTML = formatAssistantMessageAsHtml(text);
+    } else {
+      textDiv.textContent = text;
+    }
     el.appendChild(textDiv);
 
     if (contextLabels.length > 0) {

--- a/src/webview/slashMenu.ts
+++ b/src/webview/slashMenu.ts
@@ -22,6 +22,7 @@ const SLASH_ITEMS: SlashMenuItem[] = [
   { command: '/task', label: '/task', description: 'Search Planner and Microsoft To Do tasks', icon: getSourceTextIcon('todo'), sourceIcon: 'todo' },
   { command: '/all', label: '/all', description: 'Search all sources explicitly', icon: getSourceTextIcon('all'), sourceIcon: 'all' },
   { command: '/ask', label: '/ask', description: 'Ask Microsoft 365 Copilot using pinned snippets in the panel', icon: '🤖' },
+  { command: '/workiq', label: '/workiq', description: 'Ask Work IQ using Microsoft 365 work intelligence', icon: '🧠' },
   { command: '/clear', label: '/clear', description: 'Clear chat and discard pinned snippets', icon: '🧹' },
 ];
 


### PR DESCRIPTION
## Summary

Add a `/workiq` slash command that sends natural language queries to the Microsoft Work IQ Gateway via the A2A v1.0 (Agent-to-Agent) protocol. Work IQ provides AI-powered access to Microsoft 365 work intelligence (emails, meetings, files, organizational knowledge).

Closes #48

## Changes

### New files
- **`src/adapters/workIqAdapter.ts`**: A2A v1.0 JSON-RPC client
  - `SendMessage` method with proper JSON-RPC 2.0 envelope
  - `A2A-Version: 1.0` header for v1.0 protocol dispatch
  - Location metadata (timezone) for time-sensitive queries
  - Multi-turn conversation support via `contextId`
  - Dedicated retry logic (only 429/503, avoids duplicating prompts)
  - HTTP and JSON-RPC error handling
- **`src/test/suite/workIqAdapter.test.ts`**: Comprehensive unit tests
- **`docs/work_iq.md`**: Setup guide (enabling Work IQ API, permissions, troubleshooting)
- **`docs/work_iq_ja.md`**: Japanese translation

### Modified files
- **`src/router/commandRouter.ts`**: Added `workiq` as operation command (like `/ask`)
- **`src/auth/authScopes.ts`**: Added Work IQ scope constants and `buildWorkIqProviderScopes()`
- **`src/auth/authProvider.ts`**: Added `getWorkIqAccessToken()` with separate session caching
- **`src/panel/chatViewProvider.ts`**: Added `handleWorkIqCommand()` with separate `contextId`
- **`src/test/suite/commandRouter.test.ts`**: Added `/workiq` routing tests
- **`README.md`**: Added `/workiq` command to features table and usage section

## Design Decisions

1. **Operation command pattern**: `/workiq` is handled like `/ask` — an operation that forwards the entire remaining text as query. Other slash commands are ignored when `/workiq` is specified.

2. **Separate token acquisition**: Work IQ uses a different resource (`api://workiq.svc.cloud.microsoft`) than Graph. Separate `workIqSession` in `AuthProvider` prevents stale-token bugs.

3. **Separate contextId**: `currentWorkIqContextId` is independent from `currentConversationId` (Copilot Chat). Both are cleared on `/clear`.

4. **No request/response body logging**: Work IQ responses may contain sensitive M365 content.

## Validation

- ✅ `npm run compile` — type checks pass
- ✅ `npm run lint` — clean
- ✅ `npm test` — 200 tests passing (32 new)
- ✅ `npm run security:check` — 0 vulnerabilities