### PR TITLE
update: Upgrade GitHub Actions to Node.js 24 compatible versions

### DIFF
--- a/.github/workflows/release-vsix.yml
+++ b/.github/workflows/release-vsix.yml
@@ -17,12 +17,12 @@ jobs:
 
     steps:
       - name: Check out source
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           cache: npm
@@ -59,7 +59,7 @@ jobs:
           echo "vsix_path=${VSIX_PATH}" >> "${GITHUB_OUTPUT}"
 
       - name: Publish VSIX to GitHub Artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: vsix-${{ github.ref_name }}
           path: ${{ steps.package.outputs.vsix_path }}
@@ -67,7 +67,7 @@ jobs:
 
       - name: Build release context (diff/issues since previous release)
         id: release_notes
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const owner = context.repo.owner;
@@ -139,7 +139,7 @@ jobs:
             core.setOutput('body', body);
 
       - name: Create GitHub Release (standard style with generated notes)
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           tag_name: ${{ github.ref_name }}
           name: ${{ github.ref_name }}

--- a/.github/workflows/release-vsix.yml
+++ b/.github/workflows/release-vsix.yml
@@ -17,12 +17,12 @@ jobs:
 
     steps:
       - name: Check out source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
@@ -59,7 +59,7 @@ jobs:
           echo "vsix_path=${VSIX_PATH}" >> "${GITHUB_OUTPUT}"
 
       - name: Publish VSIX to GitHub Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: vsix-${{ github.ref_name }}
           path: ${{ steps.package.outputs.vsix_path }}
@@ -67,7 +67,7 @@ jobs:
 
       - name: Build release context (diff/issues since previous release)
         id: release_notes
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const owner = context.repo.owner;
@@ -139,7 +139,7 @@ jobs:
             core.setOutput('body', body);
 
       - name: Create GitHub Release (standard style with generated notes)
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ github.ref_name }}
           name: ${{ github.ref_name }}


### PR DESCRIPTION
## Summary

Upgrades all GitHub Actions in `release-vsix.yml` to versions that support Node.js 24, resolving the deprecation warning for Node.js 20.

## Changes

| Action | Before | After |
|--------|--------|-------|
| `actions/checkout` | `v4` | `v6` |
| `actions/setup-node` | `v4` | `v6` |
| `actions/upload-artifact` | `v4` | `v7` |
| `actions/github-script` | `v7` | `v9` |
| `softprops/action-gh-release` | `v2` | `v3` |

## Notes

- `actions/github-script@v9` has a breaking change for `require('@actions/github')`, but our script only uses injected `github`, `context`, and `core` — no impact.
- `actions/upload-artifact@v7` adds an optional `archive` parameter (not used here) — no impact.
- `softprops/action-gh-release@v3` explicitly targets Node.js 24.

Closes #54

## References

- https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/