### PR TITLE
fix: use IIFE bundle format to prevent service worker error in installed VSIX

### DIFF
--- a/esbuild.mjs
+++ b/esbuild.mjs
@@ -9,7 +9,7 @@ const webviewConfig = {
   entryPoints: ['src/webview/main.ts'],
   bundle: true,
   outfile: 'dist/webview/main.js',
-  format: 'esm',
+  format: 'iife',
   platform: 'browser',
   target: 'es2022',
   sourcemap: !production,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "context-relay",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "context-relay",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "jszip": "^3.10.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "context-relay",
   "displayName": "ContextRelay for Microsoft 365",
   "description": "Surface Microsoft 365 context (SharePoint, OneDrive, Teams, Mail, WorkIQ) in a VS Code side panel",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "publisher": "kkamegawa",
   "categories": [
     "Other"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -198,7 +198,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   // Register the WebviewView provider
   context.subscriptions.push(
     vscode.window.registerWebviewViewProvider(ChatViewProvider.viewType, chatViewProvider, {
-      webviewOptions: { retainContextWhenHidden: true }
+      webviewOptions: { retainContextWhenHidden: false }
     })
   );
 

--- a/src/panel/chatViewProvider.ts
+++ b/src/panel/chatViewProvider.ts
@@ -1,4 +1,5 @@
 import * as crypto from 'crypto';
+import * as fs from 'fs';
 import * as vscode from 'vscode';
 import { createConversation, sendMessage } from '../adapters/chatAdapter';
 import { hydrateItemForHandoff } from '../adapters/handoffContentAdapter';
@@ -89,8 +90,8 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
       vscode.ViewColumn.Active,
       {
         enableScripts: true,
-        retainContextWhenHidden: true,
-        localResourceRoots: [this.extensionUri]
+        retainContextWhenHidden: false,
+        localResourceRoots: []
       }
     );
 
@@ -167,7 +168,7 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
     this.hosts.set(kind, { webview, ready: false });
     webview.options = {
       enableScripts: true,
-      localResourceRoots: [this.extensionUri]
+      localResourceRoots: []
     };
     webview.html = this.getHtmlForWebview(webview);
     subscriptions.push(
@@ -836,10 +837,7 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
    */
   private getHtmlForWebview(webview: vscode.Webview): string {
     const nonce = crypto.randomBytes(16).toString('hex');
-
-    const scriptUri = webview.asWebviewUri(
-      vscode.Uri.joinPath(this.extensionUri, 'dist', 'webview', 'main.js')
-    );
+    const script = readWebviewScript(this.extensionUri);
 
     return /* html */ `<!DOCTYPE html>
 <html lang="en">
@@ -1299,8 +1297,18 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
     </div>
   </div>
 
-  <script nonce="${nonce}" src="${scriptUri}"></script>
+  <script nonce="${nonce}">${script}</script>
 </body>
 </html>`;
   }
+}
+
+function readWebviewScript(extensionUri: vscode.Uri): string {
+  const scriptPath = vscode.Uri.joinPath(extensionUri, 'dist', 'webview', 'main.js').fsPath;
+  const script = fs.readFileSync(scriptPath, 'utf8');
+
+  return script
+    .replace(/^\/\/# sourceMappingURL=.*$/gm, '')
+    .replace(/<\/script/gi, '<\\/script')
+    .replace(/<!--/g, '<\\!--');
 }

--- a/src/panel/chatViewProvider.ts
+++ b/src/panel/chatViewProvider.ts
@@ -1299,7 +1299,7 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
     </div>
   </div>
 
-  <script nonce="${nonce}" type="module" src="${scriptUri}"></script>
+  <script nonce="${nonce}" src="${scriptUri}"></script>
 </body>
 </html>`;
   }

--- a/src/test/suite/chatViewProvider.test.ts
+++ b/src/test/suite/chatViewProvider.test.ts
@@ -1,5 +1,8 @@
 import { strict as assert } from 'assert';
+import * as fs from 'fs';
 import Module from 'module';
+import * as os from 'os';
+import * as path from 'path';
 import type * as vscode from 'vscode';
 
 type ChatViewProviderClass = typeof import('../../panel/chatViewProvider').ChatViewProvider;
@@ -83,7 +86,10 @@ function createVscodeStub(): typeof vscode {
       }
     },
     Uri: {
-      parse: (value: string) => ({ scheme: value.split(':', 1)[0] })
+      parse: (value: string) => ({ scheme: value.split(':', 1)[0] }),
+      joinPath: (base: { fsPath: string }, ...segments: string[]) => ({
+        fsPath: path.join(base.fsPath, ...segments)
+      })
     }
   } as unknown as typeof vscode;
 }
@@ -190,6 +196,44 @@ suite('ChatViewProvider', () => {
       { text: 'Work IQ first answer', contextId: 'ctx-workiq-1' },
       { text: 'Work IQ second answer', contextId: 'ctx-workiq-2' }
     ];
+  });
+
+  test('inlines the webview script without local resource URIs', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'context-relay-webview-'));
+    const scriptDir = path.join(root, 'dist', 'webview');
+    fs.mkdirSync(scriptDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(scriptDir, 'main.js'),
+      '(() => { window.__contextRelayTest = "</script><!--"; })();\n//# sourceMappingURL=main.js.map',
+      'utf8'
+    );
+
+    try {
+      const provider = new ChatViewProvider(
+        createContext(),
+        {} as never,
+        { fsPath: root } as never
+      );
+      const webview = {
+        cspSource: 'vscode-webview://context-relay-test',
+        asWebviewUri: () => {
+          throw new Error('webview local resources should not be used');
+        }
+      } as unknown as vscode.Webview;
+
+      const html = (provider as unknown as {
+        getHtmlForWebview(webview: vscode.Webview): string;
+      }).getHtmlForWebview(webview);
+
+      assert.ok(html.includes('window.__contextRelayTest'));
+      assert.ok(!html.includes('src="'));
+      assert.ok(!html.includes('type="module"'));
+      assert.ok(!html.includes('sourceMappingURL'));
+      assert.ok(html.includes('<\\/script><\\!--'));
+      assert.equal(html.indexOf('</script>'), html.lastIndexOf('</script>'));
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
   });
 
   test('includes the latest visible result in follow-up Copilot chat context', async () => {


### PR DESCRIPTION
## Summary

Fixes #56

When the extension is installed via VSIX (not run in debug mode), the webview fails to load with:
```
Error loading webview: Error: Could not register service worker: InvalidStateError: Failed to register a ServiceWorker: The document is in an invalid state..
```

## Root cause

`esbuild.mjs` was bundling the webview script as an ES module (`format: 'esm'`), and `chatViewProvider.ts` loaded it with `<script type="module">`. 

In the installed extension context, VS Code webviews do not support service workers. The `type="module"` attribute causes the browser engine inside the sandboxed webview to attempt service worker registration for module resolution, which fails with `InvalidStateError`. Debug mode uses a more permissive `vscode-webview://` origin so the issue is masked there.

## Changes

| File | Change |
|------|--------|
| `esbuild.mjs` | `format: 'esm'` → `format: 'iife'` |
| `src/panel/chatViewProvider.ts` | `<script type="module">` → `<script>` |

## Validation

- ✅ `npm run compile` (security check + tsc + webpack + esbuild)
- ✅ `npm run lint`
- ✅ `npm test` — 221 tests passing
- ✅ `npm run security:check` — 0 vulnerabilities