### PR TITLE
fix: add top-level icon field and SVG dimensions for correct icon display

### DIFF
--- a/media/contextRelay-icon.svg
+++ b/media/contextRelay-icon.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="_レイヤー_1" data-name="レイヤー_1" xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 1024 1024">
+<svg id="_レイヤー_1" data-name="レイヤー_1" xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 1024 1024" width="1024" height="1024">
   <!-- Generator: Adobe Illustrator 30.2.1, SVG Export Plug-In . SVG Version: 2.1.1 Build 1)  -->
   <defs>
     <style>

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "search",
     "productivity"
   ],
+  "icon": "media/icon.png",
   "preview": true,
   "pricing": "Free",
   "license": "MIT",


### PR DESCRIPTION
## Problem

`contextRelay-icon.svg` was not being displayed as the extension icon.

## Root Causes

1. **Missing top-level `"icon"` field** in `package.json` — VS Code requires this to show the custom icon in the Extensions panel and Marketplace. Without it, the default puzzle-piece placeholder is shown.

2. **SVG had no explicit `width`/`height` attributes** — `contextRelay-icon.svg` specified only `viewBox="0 0 1024 1024"` with no `width`/`height`. Some VS Code icon rendering contexts (e.g. `<img>`-based loading) fall back to the browser's default SVG size (300×150) when these attributes are absent, which can prevent the icon from rendering correctly in the Activity Bar.

## Changes

- `package.json` — Add `"icon": "media/icon.png"` at the top level to register the extension's icon for the Extensions panel and Marketplace.
- `media/contextRelay-icon.svg` — Add `width="1024" height="1024"` to the root `<svg>` element to match its `viewBox`, ensuring consistent rendering across all VS Code icon loading contexts.

## Validation

- ✅ `npm run compile` (includes `npm run security:check`)
- ✅ `npm run lint`
- ✅ `npm test` — 222 tests passing (includes `"uses an SVG file for the activity bar icon"`)
- ✅ `npm run security:check` — 0 vulnerabilities

Closes #58