### PR TITLE
fix: use external script URI to eliminate 20-second panel open delay

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "context-relay",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "context-relay",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
         "jszip": "^3.10.1",

--- a/src/panel/chatViewProvider.ts
+++ b/src/panel/chatViewProvider.ts
@@ -1,5 +1,4 @@
 import * as crypto from 'crypto';
-import * as fs from 'fs';
 import * as vscode from 'vscode';
 import { createConversation, sendMessage } from '../adapters/chatAdapter';
 import { hydrateItemForHandoff } from '../adapters/handoffContentAdapter';
@@ -91,7 +90,7 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
       {
         enableScripts: true,
         retainContextWhenHidden: false,
-        localResourceRoots: []
+        localResourceRoots: [vscode.Uri.joinPath(this.extensionUri, 'dist', 'webview')]
       }
     );
 
@@ -168,7 +167,7 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
     this.hosts.set(kind, { webview, ready: false });
     webview.options = {
       enableScripts: true,
-      localResourceRoots: []
+      localResourceRoots: [vscode.Uri.joinPath(this.extensionUri, 'dist', 'webview')]
     };
     webview.html = this.getHtmlForWebview(webview);
     subscriptions.push(
@@ -837,7 +836,9 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
    */
   private getHtmlForWebview(webview: vscode.Webview): string {
     const nonce = crypto.randomBytes(16).toString('hex');
-    const script = readWebviewScript(this.extensionUri);
+    const scriptUri = webview.asWebviewUri(
+      vscode.Uri.joinPath(this.extensionUri, 'dist', 'webview', 'main.js')
+    );
 
     return /* html */ `<!DOCTYPE html>
 <html lang="en">
@@ -848,7 +849,7 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
     content="default-src 'none';
       style-src 'unsafe-inline' ${webview.cspSource};
       font-src ${webview.cspSource};
-      script-src 'nonce-${nonce}';">
+      script-src 'nonce-${nonce}' ${webview.cspSource};">
   <title>ContextRelay</title>
   <style>
     :root {
@@ -1297,18 +1298,8 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
     </div>
   </div>
 
-  <script nonce="${nonce}">${script}</script>
+  <script nonce="${nonce}" src="${scriptUri}" defer></script>
 </body>
 </html>`;
   }
-}
-
-function readWebviewScript(extensionUri: vscode.Uri): string {
-  const scriptPath = vscode.Uri.joinPath(extensionUri, 'dist', 'webview', 'main.js').fsPath;
-  const script = fs.readFileSync(scriptPath, 'utf8');
-
-  return script
-    .replace(/^\/\/# sourceMappingURL=.*$/gm, '')
-    .replace(/<\/script/gi, '<\\/script')
-    .replace(/<!--/g, '<\\!--');
 }

--- a/src/test/suite/chatViewProvider.test.ts
+++ b/src/test/suite/chatViewProvider.test.ts
@@ -1,5 +1,4 @@
 import { strict as assert } from 'assert';
-import * as fs from 'fs';
 import Module from 'module';
 import * as os from 'os';
 import * as path from 'path';
@@ -198,42 +197,30 @@ suite('ChatViewProvider', () => {
     ];
   });
 
-  test('inlines the webview script without local resource URIs', () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'context-relay-webview-'));
-    const scriptDir = path.join(root, 'dist', 'webview');
-    fs.mkdirSync(scriptDir, { recursive: true });
-    fs.writeFileSync(
-      path.join(scriptDir, 'main.js'),
-      '(() => { window.__contextRelayTest = "</script><!--"; })();\n//# sourceMappingURL=main.js.map',
-      'utf8'
+  test('loads the webview script via external URI (no blocking file read)', () => {
+    const root = path.join(os.tmpdir(), 'context-relay-webview-test');
+
+    const provider = new ChatViewProvider(
+      createContext(),
+      {} as never,
+      { fsPath: root, joinPath: (...segments: string[]) => ({ fsPath: path.join(root, ...segments) }) } as never
     );
 
-    try {
-      const provider = new ChatViewProvider(
-        createContext(),
-        {} as never,
-        { fsPath: root } as never
-      );
-      const webview = {
-        cspSource: 'vscode-webview://context-relay-test',
-        asWebviewUri: () => {
-          throw new Error('webview local resources should not be used');
-        }
-      } as unknown as vscode.Webview;
+    const scriptWebviewUri = 'vscode-webview-resource://dist/webview/main.js';
+    const webview = {
+      cspSource: 'vscode-webview://context-relay-test',
+      asWebviewUri: () => ({ toString: () => scriptWebviewUri })
+    } as unknown as vscode.Webview;
 
-      const html = (provider as unknown as {
-        getHtmlForWebview(webview: vscode.Webview): string;
-      }).getHtmlForWebview(webview);
+    const html = (provider as unknown as {
+      getHtmlForWebview(webview: vscode.Webview): string;
+    }).getHtmlForWebview(webview);
 
-      assert.ok(html.includes('window.__contextRelayTest'));
-      assert.ok(!html.includes('src="'));
-      assert.ok(!html.includes('type="module"'));
-      assert.ok(!html.includes('sourceMappingURL'));
-      assert.ok(html.includes('<\\/script><\\!--'));
-      assert.equal(html.indexOf('</script>'), html.lastIndexOf('</script>'));
-    } finally {
-      fs.rmSync(root, { recursive: true, force: true });
-    }
+    // Script is loaded via src= attribute, not inlined
+    assert.ok(html.includes(`src="${scriptWebviewUri}"`), 'HTML should reference the external script URI');
+    assert.ok(html.includes('defer'), 'script tag should have defer so the panel HTML renders first');
+    // CSP must allow the webview cspSource for the external script to load
+    assert.ok(html.includes(webview.cspSource), 'CSP should include webview.cspSource');
   });
 
   test('includes the latest visible result in follow-up Copilot chat context', async () => {

--- a/src/test/suite/chatViewProvider.test.ts
+++ b/src/test/suite/chatViewProvider.test.ts
@@ -1,4 +1,5 @@
 import { strict as assert } from 'assert';
+import * as fs from 'fs';
 import Module from 'module';
 import * as os from 'os';
 import * as path from 'path';
@@ -198,29 +199,33 @@ suite('ChatViewProvider', () => {
   });
 
   test('loads the webview script via external URI (no blocking file read)', () => {
-    const root = path.join(os.tmpdir(), 'context-relay-webview-test');
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'context-relay-webview-'));
 
-    const provider = new ChatViewProvider(
-      createContext(),
-      {} as never,
-      { fsPath: root, joinPath: (...segments: string[]) => ({ fsPath: path.join(root, ...segments) }) } as never
-    );
+    try {
+      const provider = new ChatViewProvider(
+        createContext(),
+        {} as never,
+        { fsPath: root, joinPath: (...segments: string[]) => ({ fsPath: path.join(root, ...segments) }) } as never
+      );
 
-    const scriptWebviewUri = 'vscode-webview-resource://dist/webview/main.js';
-    const webview = {
-      cspSource: 'vscode-webview://context-relay-test',
-      asWebviewUri: () => ({ toString: () => scriptWebviewUri })
-    } as unknown as vscode.Webview;
+      const scriptWebviewUri = 'vscode-webview-resource://dist/webview/main.js';
+      const webview = {
+        cspSource: 'vscode-webview://context-relay-test',
+        asWebviewUri: () => ({ toString: () => scriptWebviewUri })
+      } as unknown as vscode.Webview;
 
-    const html = (provider as unknown as {
-      getHtmlForWebview(webview: vscode.Webview): string;
-    }).getHtmlForWebview(webview);
+      const html = (provider as unknown as {
+        getHtmlForWebview(webview: vscode.Webview): string;
+      }).getHtmlForWebview(webview);
 
-    // Script is loaded via src= attribute, not inlined
-    assert.ok(html.includes(`src="${scriptWebviewUri}"`), 'HTML should reference the external script URI');
-    assert.ok(html.includes('defer'), 'script tag should have defer so the panel HTML renders first');
-    // CSP must allow the webview cspSource for the external script to load
-    assert.ok(html.includes(webview.cspSource), 'CSP should include webview.cspSource');
+      // Script is loaded via src= attribute, not inlined
+      assert.ok(html.includes(`src="${scriptWebviewUri}"`), 'HTML should reference the external script URI');
+      assert.ok(html.includes('defer'), 'script tag should have defer so the panel HTML renders first');
+      // CSP must allow the webview cspSource for the external script to load
+      assert.ok(html.includes(webview.cspSource), 'CSP should include webview.cspSource');
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
   });
 
   test('includes the latest visible result in follow-up Copilot chat context', async () => {

--- a/src/webview/main.ts
+++ b/src/webview/main.ts
@@ -209,6 +209,7 @@ window.addEventListener('message', (event) => {
 });
 
 // Notify the extension only after all webview handlers are registered.
+// With `defer` the DOM is already parsed when this runs; the readyState guard is a fallback for non-defer execution.
 function initWebview(): void {
   vscode.postMessage({ command: 'webviewReady' });
   promptInput.focus();

--- a/src/webview/main.ts
+++ b/src/webview/main.ts
@@ -79,21 +79,6 @@ function clearPendingSubmission(): void {
 
 // --- Event listeners ---
 
-// Notify extension that webview is ready.
-// The script is loaded with `defer`, so the DOM is fully parsed by the time
-// this code runs. We post `webviewReady` directly instead of waiting for
-// the DOMContentLoaded event (which has already fired).
-function initWebview(): void {
-  vscode.postMessage({ command: 'webviewReady' });
-  promptInput.focus();
-}
-
-if (document.readyState === 'loading') {
-  window.addEventListener('DOMContentLoaded', initWebview);
-} else {
-  initWebview();
-}
-
 // Send button click
 sendButton.addEventListener('click', submitQuery);
 
@@ -222,3 +207,15 @@ window.addEventListener('message', (event) => {
       break;
   }
 });
+
+// Notify the extension only after all webview handlers are registered.
+function initWebview(): void {
+  vscode.postMessage({ command: 'webviewReady' });
+  promptInput.focus();
+}
+
+if (document.readyState === 'loading') {
+  window.addEventListener('DOMContentLoaded', initWebview);
+} else {
+  initWebview();
+}

--- a/src/webview/main.ts
+++ b/src/webview/main.ts
@@ -79,11 +79,20 @@ function clearPendingSubmission(): void {
 
 // --- Event listeners ---
 
-// Notify extension that webview is ready
-window.addEventListener('DOMContentLoaded', () => {
+// Notify extension that webview is ready.
+// The script is loaded with `defer`, so the DOM is fully parsed by the time
+// this code runs. We post `webviewReady` directly instead of waiting for
+// the DOMContentLoaded event (which has already fired).
+function initWebview(): void {
   vscode.postMessage({ command: 'webviewReady' });
   promptInput.focus();
-});
+}
+
+if (document.readyState === 'loading') {
+  window.addEventListener('DOMContentLoaded', initWebview);
+} else {
+  initWebview();
+}
 
 // Send button click
 sendButton.addEventListener('click', submitQuery);


### PR DESCRIPTION
## Problem

Opening the ContextRelay panel was taking 20+ seconds. The root cause was `readWebviewScript()` in `chatViewProvider.ts`, which called `fs.readFileSync('dist/webview/main.js')` synchronously on the VS Code extension host's main thread. On Windows, reading a `.js` file triggers Defender/AV scanning, which can stall for 20+ seconds. This happened on **every panel open** because `retainContextWhenHidden: false` means the webview is destroyed when hidden and recreated when shown.

## Solution

Switch from inlining the script to loading it via **external script URI** — the standard VS Code webview pattern:

- `localResourceRoots` now includes `dist/webview` so VS Code allows serving the file
- `webview.asWebviewUri(scriptPath)` converts the local path to a webview-accessible URI
- `<script defer src="...">` is used so the panel HTML renders first, then the browser fetches the script asynchronously — the extension host thread is never blocked
- CSP gains `${webview.cspSource}` to allow loading from the webview resource scheme
- `readWebviewScript` function is removed entirely (no more blocking I/O)
- `main.ts` initialization handles `defer` correctly via a `readyState` guard

## Changes

- `src/panel/chatViewProvider.ts`: removed `fs` import; fixed `localResourceRoots`; switched to external script URI; updated CSP; removed `readWebviewScript`
- `src/webview/main.ts`: replaced `DOMContentLoaded` listener with `initWebview()` + `readyState` guard
- `src/test/suite/chatViewProvider.test.ts`: updated test to assert the new external-URI behavior

Closes #61