### PR TITLE
fix: remediate remaining High CodeQL alerts

### DIFF
--- a/.github/skills/code-scanning-security-guard/SKILL.md
+++ b/.github/skills/code-scanning-security-guard/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: code-scanning-security-guard
+description: "Use when fixing GitHub Advanced Security / CodeQL findings, especially URL validation, webview rendering, preview extraction, and sanitizer regressions."
+argument-hint: "Run code scanning remediation workflow for this change"
+user-invocable: true
+---
+
+# Code Scanning Security Guard
+
+## Purpose
+This skill standardizes how ContextRelay fixes GitHub Advanced Security and CodeQL findings without creating new false confidence or compatibility regressions.
+
+## Mandatory Rules
+1. Fix the **production sink or shared helper**, not only a test or a local reimplementation.
+2. Do **not** rely on substring checks for trust decisions about hosts, resources, URLs, or schemes.
+3. Do **not** rely on ad-hoc regex sanitizers for HTML/XML security boundaries when a safer shared parsing or extraction path is available.
+4. Regression tests must exercise the **real production helper/module** used by the product code; avoid tautological tests or test-only clones of security logic.
+5. Finish only when the targeted GitHub Advanced Security findings are gone for the PR branch.
+
+## Required Workflow
+1. Create an **English GitHub issue** before starting implementation and work on a linked branch.
+2. Triage the active CodeQL findings and group them by root cause (for example: URL validation, HTML rendering, entity decoding, webview sinks).
+3. Prefer these remediation patterns:
+   - **URL/resource validation**: parse and validate exact protocol/host/path structure instead of `includes(...)`.
+   - **Webview rendering**: prefer DOM APIs, strict allowlists, safe preview fallbacks, and vetted blob/data URL handling.
+   - **Text extraction / entity handling**: use shared one-pass decoding or structured extraction helpers instead of duplicated decode chains.
+4. Add regression tests that would fail if the fix is removed or weakened.
+5. Run full validation:
+   - `npm run compile`
+   - `npm run lint`
+   - `npm test`
+   - `npm run security:check`
+6. Open a PR in English that links the tracking issue and summarizes:
+   - the exact findings addressed
+   - the production helpers or sinks changed
+   - the regression tests added
+7. Re-check GitHub Advanced Security / Code Scanning for the PR branch and continue until the targeted findings are closed.
+
+## Repository-specific lessons from earlier fixes
+- Prefer a **shared production helper** over fixing the same decoding/sanitization logic in multiple files independently.
+- If a test was flagged by CodeQL, rewrite the assertion to use a stricter production-like check instead of suppressing the alert.
+- For preview/webview paths, safer plain-text fallback behavior is preferable to reparsing risky content in the browser context.
+
+## Final response checklist
+- Tracking issue and PR are linked
+- Targeted findings are closed
+- Validation command results are included
+- New or updated regression tests are identified

--- a/src/adapters/handoffContentAdapter.ts
+++ b/src/adapters/handoffContentAdapter.ts
@@ -4,7 +4,7 @@ import { createMailPreview, getMailMessageId, normalizePreviewText } from '../pa
 import { graphFetchWithRetry, handleGraphResponse, GRAPH_BASE } from './graphClient';
 import { extractWordprocessingText } from '../textExtraction';
 
-export { extractWordprocessingText } from '../textExtraction';
+export { extractWordprocessingText };
 
 interface MailBodyResponse {
   body?: {

--- a/src/adapters/handoffContentAdapter.ts
+++ b/src/adapters/handoffContentAdapter.ts
@@ -2,6 +2,9 @@ import JSZip from 'jszip';
 import { ContextItem, getPreviewText } from '../models/contextItem';
 import { createMailPreview, getMailMessageId, normalizePreviewText } from '../panel/itemPreview';
 import { graphFetchWithRetry, handleGraphResponse, GRAPH_BASE } from './graphClient';
+import { extractWordprocessingText } from '../textExtraction';
+
+export { extractWordprocessingText } from '../textExtraction';
 
 interface MailBodyResponse {
   body?: {
@@ -198,22 +201,6 @@ export function inferDriveContentMode(name: string, mimeType?: string): DriveCon
   return 'unsupported';
 }
 
-export function extractWordprocessingText(xml: string): string {
-  return decodeXmlEntities(
-    xml
-      .replace(/<w:tab\s*\/?>/gi, '\t')
-      .replace(/<w:(?:br|cr)\s*\/?>/gi, '\n')
-      .replace(/<\/w:p>/gi, '\n\n')
-      .replace(/<[^>]+>/g, '')
-  )
-    .replace(/\r\n/g, '\n')
-    .replace(/[ \t]+\n/g, '\n')
-    .replace(/\n[ \t]+/g, '\n')
-    .replace(/\n{3,}/g, '\n\n')
-    .replace(/[ \t]{2,}/g, ' ')
-    .trim();
-}
-
 export function normalizeDownloadedText(value: string): string {
   return value
     .replace(/\uFEFF/g, '')
@@ -226,18 +213,6 @@ export function normalizeDownloadedText(value: string): string {
 function getExtension(name: string): string {
   const index = name.lastIndexOf('.');
   return index === -1 ? '' : name.slice(index + 1).toLowerCase();
-}
-
-function decodeXmlEntities(value: string): string {
-  return value
-    .replace(/&nbsp;/gi, ' ')
-    .replace(/&amp;/gi, '&')
-    .replace(/&lt;/gi, '<')
-    .replace(/&gt;/gi, '>')
-    .replace(/&quot;/gi, '"')
-    .replace(/&#39;/gi, "'")
-    .replace(/&#x([0-9a-f]+);/gi, (_, hex: string) => String.fromCodePoint(parseInt(hex, 16)))
-    .replace(/&#(\d+);/g, (_, decimal: string) => String.fromCodePoint(parseInt(decimal, 10)));
 }
 
 function asDriveItemRaw(raw: unknown): DriveItemRaw | undefined {

--- a/src/adapters/retrievalSearchUtils.ts
+++ b/src/adapters/retrievalSearchUtils.ts
@@ -13,7 +13,11 @@ export function stripSearchMarkup(value: string): string {
 export function isOneDriveUrl(url: string): boolean {
   try {
     const parsed = new URL(url);
-    return parsed.hostname.includes('-my.sharepoint.com') || parsed.pathname.includes('/personal/');
+    return (
+      parsed.protocol === 'https:' &&
+      /^[a-z0-9-]+-my\.sharepoint\.com$/i.test(parsed.hostname) &&
+      /^\/personal\/[^/]+(?:\/|$)/i.test(parsed.pathname)
+    );
   } catch {
     return false;
   }

--- a/src/panel/itemPreview.ts
+++ b/src/panel/itemPreview.ts
@@ -1,5 +1,6 @@
 import sanitizeHtml from 'sanitize-html';
 import { ContextItem, PreviewContent, ResolvedPreview } from '../models/contextItem';
+import { decodeHtmlEntitiesOnce } from '../textExtraction';
 
 interface MailItemRaw {
   messageId?: string;
@@ -293,7 +294,7 @@ export function normalizePreviewText(value: string, isHtml = false): string {
       .replace(/<[^>]+>/g, ' ');
   }
 
-  normalized = decodeHtmlEntities(normalized)
+  normalized = decodeHtmlEntitiesOnce(normalized)
     .replace(/\r\n/g, '\n')
     .replace(/\r/g, '\n')
     .replace(/\u00a0/g, ' ')
@@ -340,19 +341,6 @@ export function sanitizePreviewHtml(value: string): string {
     }
   }).trim();
 }
-
-function decodeHtmlEntities(value: string): string {
-  return value
-    .replace(/&nbsp;/gi, ' ')
-    .replace(/&amp;/gi, '&')
-    .replace(/&lt;/gi, '<')
-    .replace(/&gt;/gi, '>')
-    .replace(/&quot;/gi, '"')
-    .replace(/&#39;/gi, "'")
-    .replace(/&#x([0-9a-f]+);/gi, (_, hex: string) => String.fromCodePoint(parseInt(hex, 16)))
-    .replace(/&#(\d+);/g, (_, decimal: string) => String.fromCodePoint(parseInt(decimal, 10)));
-}
-
 function asMailItemRaw(raw: unknown): MailItemRaw | undefined {
   return raw && typeof raw === 'object' ? raw as MailItemRaw : undefined;
 }

--- a/src/panel/previewResolver.ts
+++ b/src/panel/previewResolver.ts
@@ -1,6 +1,7 @@
 import JSZip from 'jszip';
 import { ContextItem, ResolvedPreview } from '../models/contextItem';
 import { graphFetchWithRetry, handleGraphResponse, GRAPH_BASE } from '../adapters/graphClient';
+import { extractWordprocessingText } from '../textExtraction';
 import {
   createFallbackPreview,
   createImagePreviewContent,
@@ -237,34 +238,6 @@ async function extractDocxPreview(bytes: Uint8Array): Promise<{ text: string }> 
   }
 
   return { text: parts.join('\n\n').trim() };
-}
-
-function extractWordprocessingText(xml: string): string {
-  return decodeXmlEntities(
-    xml
-      .replace(/<w:tab\s*\/?>/gi, '\t')
-      .replace(/<w:(?:br|cr)\s*\/?>/gi, '\n')
-      .replace(/<\/w:p>/gi, '\n\n')
-      .replace(/<[^>]+>/g, '')
-  )
-    .replace(/\r\n/g, '\n')
-    .replace(/[ \t]+\n/g, '\n')
-    .replace(/\n[ \t]+/g, '\n')
-    .replace(/\n{3,}/g, '\n\n')
-    .replace(/[ \t]{2,}/g, ' ')
-    .trim();
-}
-
-function decodeXmlEntities(value: string): string {
-  return value
-    .replace(/&nbsp;/gi, ' ')
-    .replace(/&amp;/gi, '&')
-    .replace(/&lt;/gi, '<')
-    .replace(/&gt;/gi, '>')
-    .replace(/&quot;/gi, '"')
-    .replace(/&#39;/gi, "'")
-    .replace(/&#x([0-9a-f]+);/gi, (_, hex: string) => String.fromCodePoint(parseInt(hex, 16)))
-    .replace(/&#(\d+);/g, (_, decimal: string) => String.fromCodePoint(parseInt(decimal, 10)));
 }
 
 function getExtension(name: string): string {

--- a/src/test/suite/handoffContentAdapter.test.ts
+++ b/src/test/suite/handoffContentAdapter.test.ts
@@ -31,6 +31,19 @@ suite('Handoff content adapter', () => {
     assert.equal(extractWordprocessingText(xml), 'Hello world\n\nSecond paragraph\nLine 2');
   });
 
+  test('decodes entities once when extracting Wordprocessing XML text', () => {
+    const xml = [
+      '<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">',
+      '<w:body>',
+      '<w:p><w:r><w:t>&amp;lt;script&amp;gt;alert(1)&amp;lt;/script&amp;gt;</w:t></w:r></w:p>',
+      '<w:p><w:r><w:t>&#x1F642;</w:t></w:r></w:p>',
+      '</w:body>',
+      '</w:document>'
+    ].join('');
+
+    assert.equal(extractWordprocessingText(xml), '&lt;script&gt;alert(1)&lt;/script&gt;\n\n🙂');
+  });
+
   test('normalizes downloaded text and strips BOM', () => {
     assert.equal(normalizeDownloadedText('\uFEFFline1\r\n\r\n\r\nline2\r'), 'line1\n\nline2');
   });

--- a/src/test/suite/itemPreview.test.ts
+++ b/src/test/suite/itemPreview.test.ts
@@ -24,6 +24,11 @@ suite('Item preview', () => {
     assert.equal(text, 'Hello world\nLine 2');
   });
 
+  test('decodes html entities without double decoding nested values', () => {
+    const text = normalizePreviewText('&amp;lt;script&amp;gt;alert(1)&amp;lt;/script&amp;gt;', true);
+    assert.equal(text, '&lt;script&gt;alert(1)&lt;/script&gt;');
+  });
+
   test('creates fallback preview from retrieval extracts', () => {
     const preview = createFallbackPreview(makeItem({
       source: 'sharepoint',

--- a/src/test/suite/retrievalAdapter.test.ts
+++ b/src/test/suite/retrievalAdapter.test.ts
@@ -49,6 +49,25 @@ suite('Retrieval adapter', () => {
     );
   });
 
+  test('rejects crafted or incomplete OneDrive-looking URLs', () => {
+    assert.equal(
+      isOneDriveUrl('https://contoso-my.sharepoint.com.attacker.test/personal/user_contoso_com/Documents/file.docx'),
+      false
+    );
+    assert.equal(
+      isOneDriveUrl('https://example.test/personal/user_contoso_com/Documents/file.docx'),
+      false
+    );
+    assert.equal(
+      isOneDriveUrl('https://contoso-my.sharepoint.com/sites/group/Documents/file.docx'),
+      false
+    );
+    assert.equal(
+      isOneDriveUrl('http://contoso-my.sharepoint.com/personal/user_contoso_com/Documents/file.docx'),
+      false
+    );
+  });
+
   test('removes search highlight markup from summaries', () => {
     assert.equal(stripSearchMarkup('<c0>Project</c0> plan <ddd/> preview'), 'Project plan … preview');
   });

--- a/src/test/suite/textExtraction.test.ts
+++ b/src/test/suite/textExtraction.test.ts
@@ -1,0 +1,31 @@
+import { strict as assert } from 'assert';
+import { decodeHtmlEntitiesOnce, extractWordprocessingText } from '../../textExtraction';
+
+suite('Text extraction helpers', () => {
+  test('decodes supported entities in a single pass', () => {
+    assert.equal(
+      decodeHtmlEntitiesOnce('&lt;tag&gt; &amp; &#39; &#x1F600;'),
+      '<tag> & \' 😀'
+    );
+  });
+
+  test('does not double decode nested entity sequences', () => {
+    assert.equal(
+      decodeHtmlEntitiesOnce('&amp;lt;script&amp;gt;notice&amp;lt;/script&amp;gt;'),
+      '&lt;script&gt;notice&lt;/script&gt;'
+    );
+  });
+
+  test('extracts Wordprocessing text runs without generic tag stripping', () => {
+    const xml = [
+      '<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">',
+      '<w:body>',
+      '<w:p><w:r><w:t>Alpha</w:t></w:r><w:r><w:tab/></w:r><w:r><w:t>Beta</w:t></w:r></w:p>',
+      '<w:p><w:r><w:instrText>&lt;literal&gt;</w:instrText></w:r><w:r><w:br/></w:r><w:r><w:t>Gamma</w:t></w:r></w:p>',
+      '</w:body>',
+      '</w:document>'
+    ].join('');
+
+    assert.equal(extractWordprocessingText(xml), 'Alpha\tBeta\n\n<literal>\nGamma');
+  });
+});

--- a/src/test/suite/workIqAdapter.test.ts
+++ b/src/test/suite/workIqAdapter.test.ts
@@ -591,7 +591,7 @@ suite('WorkIqAdapter', () => {
 
     test('does not include Graph scopes', () => {
       const scopes = buildWorkIqProviderScopes();
-      const graphScopes = scopes.filter(s => s.includes('graph.microsoft.com'));
+      const graphScopes = scopes.filter(s => s.startsWith('https://graph.microsoft.com/'));
       assert.equal(graphScopes.length, 0);
     });
 

--- a/src/textExtraction.ts
+++ b/src/textExtraction.ts
@@ -1,0 +1,101 @@
+const HTML_ENTITY_PATTERN = /&(nbsp|amp|lt|gt|quot|#39|#x[0-9a-f]+|#\d+);/gi;
+const WORDPROCESSING_TOKEN_PATTERN = /<[^>]+>|[^<]+/g;
+const WORDPROCESSING_TEXT_START_TAG_PATTERN = /^<w:(?:t|instrText)\b/i;
+const WORDPROCESSING_TEXT_END_TAG_PATTERN = /^<\/w:(?:t|instrText)>/i;
+const WORDPROCESSING_TAB_TAG_PATTERN = /^<w:tab\b[^>]*\/?>/i;
+const WORDPROCESSING_LINE_BREAK_TAG_PATTERN = /^<w:(?:br|cr)\b[^>]*\/?>/i;
+const WORDPROCESSING_PARAGRAPH_END_TAG_PATTERN = /^<\/w:p>/i;
+
+export function decodeHtmlEntitiesOnce(value: string): string {
+  return value.replace(HTML_ENTITY_PATTERN, entity => decodeHtmlEntity(entity));
+}
+
+export function extractWordprocessingText(xml: string): string {
+  const parts: string[] = [];
+  let isInsideTextRun = false;
+
+  for (const token of xml.match(WORDPROCESSING_TOKEN_PATTERN) ?? []) {
+    if (!token.startsWith('<')) {
+      if (isInsideTextRun) {
+        parts.push(decodeHtmlEntitiesOnce(token));
+      }
+      continue;
+    }
+
+    if (WORDPROCESSING_TEXT_START_TAG_PATTERN.test(token)) {
+      isInsideTextRun = !token.endsWith('/>');
+      continue;
+    }
+
+    if (WORDPROCESSING_TEXT_END_TAG_PATTERN.test(token)) {
+      isInsideTextRun = false;
+      continue;
+    }
+
+    if (WORDPROCESSING_TAB_TAG_PATTERN.test(token)) {
+      parts.push('\t');
+      continue;
+    }
+
+    if (WORDPROCESSING_LINE_BREAK_TAG_PATTERN.test(token)) {
+      parts.push('\n');
+      continue;
+    }
+
+    if (WORDPROCESSING_PARAGRAPH_END_TAG_PATTERN.test(token)) {
+      parts.push('\n\n');
+    }
+  }
+
+  return normalizeExtractedText(parts.join(''));
+}
+
+export function normalizeExtractedText(value: string): string {
+  return value
+    .replace(/\r\n/g, '\n')
+    .replace(/[ \t]+\n/g, '\n')
+    .replace(/\n[ \t]+/g, '\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .replace(/[ \t]{2,}/g, ' ')
+    .trim();
+}
+
+function decodeHtmlEntity(entity: string): string {
+  switch (entity.toLowerCase()) {
+    case '&nbsp;':
+      return ' ';
+    case '&amp;':
+      return '&';
+    case '&lt;':
+      return '<';
+    case '&gt;':
+      return '>';
+    case '&quot;':
+      return '"';
+    case '&#39;':
+      return "'";
+    default:
+      return decodeNumericEntity(entity);
+  }
+}
+
+function decodeNumericEntity(entity: string): string {
+  if (entity.startsWith('&#x') || entity.startsWith('&#X')) {
+    return decodeCodePoint(entity.slice(3, -1), 16, entity);
+  }
+
+  if (entity.startsWith('&#')) {
+    return decodeCodePoint(entity.slice(2, -1), 10, entity);
+  }
+
+  return entity;
+}
+
+function decodeCodePoint(value: string, radix: number, fallback: string): string {
+  const codePoint = Number.parseInt(value, radix);
+  if (!Number.isInteger(codePoint) || codePoint < 0 || codePoint > 0x10ffff) {
+    return fallback;
+  }
+
+  return String.fromCodePoint(codePoint);
+}


### PR DESCRIPTION
## Summary
- harden OneDrive URL classification and the Work IQ Graph-scope regression test so substring-based checks no longer trigger CodeQL High findings
- centralize one-pass entity decoding and WordprocessingML text extraction for preview and handoff flows
- add a repository Code Scanning security skill based on the lessons from PR #81 and this remediation

## Testing
- npm run compile
- npm run lint
- npm test
- npm run security:check

Closes #82
