### PR TITLE
fix: add # file picker UI and mention context handling

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,7 +2,7 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "name": "Run ContextRelay Extension",
+      "name": "Run ContextRelay",
       "type": "extensionHost",
       "request": "launch",
       "runtimeExecutable": "${execPath}",
@@ -10,7 +10,6 @@
         "--extensionDevelopmentPath=${workspaceFolder}"
       ],
       "outFiles": [
-        "${workspaceFolder}/out/**/*.js",
         "${workspaceFolder}/dist/**/*.js"
       ],
       "preLaunchTask": "npm: compile"

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,15 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "npm: compile",
+      "type": "npm",
+      "script": "compile",
+      "group": "build",
+      "presentation": {
+        "reveal": "silent"
+      },
+      "detail": "Build the extension bundle before starting the Extension Development Host."
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -131,17 +131,28 @@ The following delegated Microsoft Graph permissions are required by feature:
   npm install
   ```
 
-4. Build the extension:
+4. Build the extension once from the terminal:
 
-  ```bash
-  npm run compile
-  ```
+   ```bash
+   npm run compile
+   ```
 
-5. Press `F5` in VS Code to launch the Extension Development Host.
+   ```powershell
+   npm run compile
+   ```
+
+5. Press `F5` in VS Code to launch the Extension Development Host. The checked-in `.vscode/launch.json` now runs `npm: compile` automatically before the debugger starts, so a clean checkout no longer fails with a missing `dist/extension.js`.
 
 Before submitting changes, run:
 
 ```bash
+npm run compile
+npm run lint
+npm test
+npm run security:check
+```
+
+```powershell
 npm run compile
 npm run lint
 npm test

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ ContextRelay is a VS Code extension that surfaces relevant Microsoft 365 context
 ## Features
 
 - **Plain Copilot chat** -- Type without a slash command to chat directly with Microsoft 365 Copilot in the panel.
+- **Local file mentions with `#`** -- Attach local workspace files (Copilot-supported extensions only) to plain Copilot chat, `/ask`, and `/workiq` prompts.
 - **Explicit source search** -- Search across connected Microsoft 365 sources with slash commands.
 - **Source targeting via slash commands** -- Narrow results to a specific source instantly.
 
@@ -22,6 +23,16 @@ ContextRelay is a VS Code extension that surfaces relevant Microsoft 365 context
 | `/ask <instruction>` | Send pinned snippets to Microsoft 365 Copilot and show the reply in the panel |
 | `/workiq <query>` | Send a natural language query to Work IQ (A2A protocol) for Microsoft 365 work intelligence |
 | `/clear` | Clear the chat transcript and discard all pinned snippets |
+
+`#` mention examples (local workspace files):
+
+```text
+Summarize #docs/plan.md
+/ask Create release notes from #"docs/Release Plan.md"
+/workiq Draft a status update using #notes/today.md
+```
+
+> **Note**: If a `#` mention is invalid (missing file, outside workspace, unsupported extension), ContextRelay blocks the request and shows an error.
 
 - **Snippet pinning** -- Save any search result as a named snippet, visible across sessions.
 - **Timestamped handoff docs** -- Generate Markdown documents that capture current context.

--- a/docs/work_iq.md
+++ b/docs/work_iq.md
@@ -68,6 +68,20 @@ Consecutive `/workiq` queries maintain conversation context via the A2A `context
 
 Use `/clear` to reset the conversation context and start fresh.
 
+### Add local workspace file context with `#`
+
+You can attach local workspace files to `/workiq` using `#` file mentions:
+
+```
+/workiq Summarize key decisions from #docs/plan.md
+/workiq Create a status email from #"notes/Release Plan.md"
+```
+
+Rules:
+- Only Copilot-supported file extensions are accepted.
+- File paths must resolve inside the opened workspace.
+- Invalid `#` mentions block the request with an error message.
+
 ### Slash command behavior
 
 When `/workiq` is specified, all other slash commands in the input are treated as part of the query text. For example:

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
       },
       "engines": {
         "node": ">=22.0.0",
-        "vscode": "^1.116.0"
+        "vscode": "^1.120.0"
       }
     },
     "node_modules/@discoveryjs/json-ext": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "context-relay",
   "displayName": "ContextRelay for Microsoft 365",
   "description": "Surface Microsoft 365 context (SharePoint, OneDrive, Teams, Mail, WorkIQ) in a VS Code side panel",
-  "version": "0.1.5",
+  "version": "0.2.0",
   "publisher": "KazushiKamegawa",
   "categories": [
     "Other"
@@ -38,7 +38,7 @@
   },
   "engines": {
     "node": ">=22.0.0",
-    "vscode": "^1.116.0"
+    "vscode": "^1.120.0"
   },
   "main": "./dist/extension.js",
   "contributes": {
@@ -285,7 +285,7 @@
     "watch": "concurrently -k \"npm:watch:extension\" \"npm:watch:webview\"",
     "prepackage": "npm run security:check",
     "package": "npm run compile:types && npm run compile:webview && webpack --mode production --devtool hidden-source-map && npm run bundle:webview:prod",
-    "vsce:package": "npx --yes @vscode/vsce@3.2.2 package --no-dependencies",
+    "vsce:package": "npx --yes @vscode/vsce@3.9.1 package --no-dependencies",
     "compile-tests": "tsc -p ./tsconfig.test.json",
     "pretest": "npm run compile-tests",
     "test": "mocha --ui tdd --timeout 10000 \"out-test/src/test/suite/**/*.test.js\"",

--- a/src/panel/chatContext.ts
+++ b/src/panel/chatContext.ts
@@ -11,6 +11,7 @@ export interface ChatContextOptions {
   snippets: SavedSnippet[];
   searchSummary?: string;
   visibleResult?: string;
+  localFiles?: { uri: string; label: string }[];
 }
 
 function buildTruncationSuffix(omittedChars: number): string {
@@ -70,12 +71,30 @@ export function buildChatContextPayload(options: ChatContextOptions): ChatContex
   const additionalContext: CopilotContextMessage[] = [];
   const contextualResources: CopilotContextualResources = {};
   const files: { uri: string }[] = [];
+  const seenFileUris = new Set<string>();
   const labels: string[] = [];
   const remainingBudget = { value: MAX_CHAT_CONTEXT_CHARS };
 
+  for (const file of options.localFiles ?? []) {
+    const uri = file.uri.trim();
+    if (!uri || seenFileUris.has(uri)) {
+      continue;
+    }
+
+    seenFileUris.add(uri);
+    files.push({ uri });
+    labels.push(file.label);
+  }
+
   for (const snippet of options.snippets) {
     if (isFileContextSnippet(snippet) && snippet.item.url) {
-      files.push({ uri: snippet.item.url });
+      const uri = snippet.item.url.trim();
+      if (!uri || seenFileUris.has(uri)) {
+        continue;
+      }
+
+      seenFileUris.add(uri);
+      files.push({ uri });
       labels.push(snippet.name || snippet.item.title);
       continue;
     }

--- a/src/panel/chatViewProvider.ts
+++ b/src/panel/chatViewProvider.ts
@@ -1,4 +1,5 @@
 import * as crypto from 'crypto';
+import * as path from 'path';
 import * as vscode from 'vscode';
 import { createConversation, sendMessage } from '../adapters/chatAdapter';
 import { hydrateItemForHandoff } from '../adapters/handoffContentAdapter';
@@ -16,6 +17,8 @@ import { type ContextItem, type ContextSource, type ResolvedPreview, getContextI
 import { getHelpText, parseCommand } from '../router/commandRouter';
 import { SnippetStore } from '../snippets/snippetStore';
 import { buildChatContextPayload } from './chatContext';
+import { isCopilotSupportedFileExtension } from './copilotSupportedExtensions';
+import { buildWorkIqPromptWithFiles, resolveFileMentions, type ResolvedFileMention } from './fileMentions';
 import { buildPreviewWebviewHtml } from './openResult';
 import { detectOutputLanguage } from './outputLanguage';
 import { resolvePreview } from './previewResolver';
@@ -115,7 +118,7 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
   public postMessage(message: HostToWebviewMessage): void {
     if (message.command === 'clearChat') {
       this.transcript = [message];
-    } else if (message.command !== 'pinnedItems') {
+    } else if (message.command !== 'pinnedItems' && message.command !== 'workspaceFiles') {
       this.transcript.push(message);
       if (this.transcript.length > ChatViewProvider.MAX_TRANSCRIPT_LENGTH) {
         this.transcript = this.transcript.slice(-ChatViewProvider.MAX_TRANSCRIPT_LENGTH);
@@ -207,6 +210,7 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
       void host.webview.postMessage(message);
     }
     this.sendPinnedItems(kind);
+    void this.sendWorkspaceFiles(kind);
   }
 
   private async handleMessage(kind: ChatHostKind, message: WebviewToHostMessage): Promise<void> {
@@ -344,6 +348,27 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
     this.broadcastMessage(message);
   }
 
+  private async sendWorkspaceFiles(kind?: ChatHostKind): Promise<void> {
+    let files: string[] = [];
+    try {
+      files = await this.collectWorkspaceFiles();
+    } catch {
+      files = [];
+    }
+
+    const message: HostToWebviewMessage = {
+      command: 'workspaceFiles',
+      files
+    };
+
+    if (kind) {
+      this.postMessageToHost(kind, message);
+      return;
+    }
+
+    this.broadcastMessage(message);
+  }
+
   private async handleOpenItemRequest(kind: ChatHostKind, item: ContextItem): Promise<void> {
     try {
       await this.handleOpenItem(item);
@@ -390,17 +415,62 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
     }
 
     if (parsed.target === 'ask') {
-      await this.handleAskCommand(parsed.query);
+      const mentionResolution = await this.resolveMentionsForPrompt(parsed.query);
+      if (!mentionResolution) {
+        return;
+      }
+
+      if (!mentionResolution.prompt.trim()) {
+        this.postMessage({
+          command: 'queryError',
+          source: 'all',
+          message: 'Prompt is empty after removing # file mentions.',
+          timestamp: new Date().toISOString()
+        });
+        return;
+      }
+
+      await this.handleAskCommand(mentionResolution.prompt, mentionResolution.files);
       return;
     }
 
     if (parsed.target === 'workiq') {
-      await this.handleWorkIqCommand(parsed.query);
+      const mentionResolution = await this.resolveMentionsForPrompt(parsed.query);
+      if (!mentionResolution) {
+        return;
+      }
+
+      if (!mentionResolution.prompt.trim()) {
+        this.postMessage({
+          command: 'queryError',
+          source: 'all',
+          message: 'Prompt is empty after removing # file mentions.',
+          timestamp: new Date().toISOString()
+        });
+        return;
+      }
+
+      await this.handleWorkIqCommand(mentionResolution.prompt, mentionResolution.files);
       return;
     }
 
     if (parsed.target === 'chat') {
-      await this.handlePlainChat(parsed.query);
+      const mentionResolution = await this.resolveMentionsForPrompt(trimmed);
+      if (!mentionResolution) {
+        return;
+      }
+
+      if (!mentionResolution.prompt.trim()) {
+        this.postMessage({
+          command: 'queryError',
+          source: 'all',
+          message: 'Prompt is empty after removing # file mentions.',
+          timestamp: new Date().toISOString()
+        });
+        return;
+      }
+
+      await this.handlePlainChat(mentionResolution.prompt, mentionResolution.files);
       return;
     }
 
@@ -517,15 +587,15 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
     });
   }
 
-  private async handleAskCommand(prompt: string): Promise<void> {
-    await this.handleCopilotChat(prompt, 'ask', true);
+  private async handleAskCommand(prompt: string, mentionFiles: readonly ResolvedFileMention[] = []): Promise<void> {
+    await this.handleCopilotChat(prompt, 'ask', true, mentionFiles);
   }
 
-  private async handlePlainChat(prompt: string): Promise<void> {
-    await this.handleCopilotChat(prompt, 'chat', false);
+  private async handlePlainChat(prompt: string, mentionFiles: readonly ResolvedFileMention[] = []): Promise<void> {
+    await this.handleCopilotChat(prompt, 'chat', false, mentionFiles);
   }
 
-  private async handleWorkIqCommand(query: string): Promise<void> {
+  private async handleWorkIqCommand(query: string, mentionFiles: readonly ResolvedFileMention[]): Promise<void> {
     this.postMessage({
       command: 'loading',
       source: 'all',
@@ -550,7 +620,8 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
     }
 
     try {
-      const response = await sendWorkIqMessage(token, query, this.currentWorkIqContextId);
+      const workIqQuery = await buildWorkIqPromptWithFiles(query, mentionFiles);
+      const response = await sendWorkIqMessage(token, workIqQuery, this.currentWorkIqContextId);
 
       if (response.contextId) {
         this.currentWorkIqContextId = response.contextId;
@@ -584,11 +655,12 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
   private async handleCopilotChat(
     prompt: string,
     kind: 'chat' | 'ask',
-    requirePinnedContext: boolean
+    requirePinnedContext: boolean,
+    mentionFiles: readonly ResolvedFileMention[] = []
   ): Promise<void> {
     const snippets = this.snippetStore.getAll();
-    if (requirePinnedContext && snippets.length === 0) {
-      const message = 'Pin one or more snippets first to use /ask. The pinned content is sent to Microsoft 365 Copilot as context.';
+    if (requirePinnedContext && snippets.length === 0 && mentionFiles.length === 0) {
+      const message = 'Pin snippets or mention local files with # to use /ask. ContextRelay sends that context to Microsoft 365 Copilot.';
       vscode.window.showWarningMessage(`ContextRelay: ${message}`);
       this.postMessage({
         command: 'queryError',
@@ -633,7 +705,11 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
       const contextPayload = buildChatContextPayload({
         snippets,
         searchSummary: this.latestSearchSummary,
-        visibleResult: this.latestVisibleResult
+        visibleResult: this.latestVisibleResult,
+        localFiles: mentionFiles.map(file => ({
+          uri: file.uri,
+          label: `Local file: ${file.relativePath}`
+        }))
       });
       const reply = await sendMessage(token, this.currentConversationId, prompt, contextPayload);
       if (!reply.trim()) {
@@ -661,6 +737,80 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
     } finally {
       this.postMessage({ command: 'loading', source: 'all', isLoading: false });
     }
+  }
+
+  private async resolveMentionsForPrompt(
+    prompt: string
+  ): Promise<{ prompt: string; files: ResolvedFileMention[] } | undefined> {
+    const workspaceRoots = (vscode.workspace.workspaceFolders ?? []).map(folder => folder.uri.fsPath);
+    const mentionResolution = await resolveFileMentions(prompt, workspaceRoots);
+    if (mentionResolution.errors.length > 0) {
+      this.postMessage({
+        command: 'queryError',
+        source: 'all',
+        message: mentionResolution.errors[0],
+        timestamp: new Date().toISOString()
+      });
+      return undefined;
+    }
+
+    return {
+      prompt: mentionResolution.cleanedPrompt,
+      files: mentionResolution.files
+    };
+  }
+
+  private async collectWorkspaceFiles(): Promise<string[]> {
+    const workspaceFolders = vscode.workspace.workspaceFolders ?? [];
+    if (workspaceFolders.length === 0) {
+      return [];
+    }
+
+    const fileUris = await vscode.workspace.findFiles(
+      '**/*',
+      '**/{.git,node_modules,dist,out,out-test,.contextrelay,coverage}/**',
+      4000
+    );
+    const groupedPaths = new Map<string, string[]>();
+
+    for (const fileUri of fileUris) {
+      if (fileUri.scheme !== 'file') {
+        continue;
+      }
+
+      const workspaceFolder = vscode.workspace.getWorkspaceFolder(fileUri);
+      if (!workspaceFolder) {
+        continue;
+      }
+
+      const relativePath = path.relative(workspaceFolder.uri.fsPath, fileUri.fsPath);
+      if (!relativePath || relativePath.startsWith('..') || path.isAbsolute(relativePath)) {
+        continue;
+      }
+
+      if (!isCopilotSupportedFileExtension(relativePath)) {
+        continue;
+      }
+
+      const normalizedRelativePath = relativePath.split(path.sep).join('/');
+      const normalizedAbsolutePath = fileUri.fsPath.split(path.sep).join('/');
+      const paths = groupedPaths.get(normalizedRelativePath) ?? [];
+      paths.push(normalizedAbsolutePath);
+      groupedPaths.set(normalizedRelativePath, paths);
+    }
+
+    const candidates: string[] = [];
+    for (const [relativePath, absolutePaths] of groupedPaths.entries()) {
+      if (absolutePaths.length === 1) {
+        candidates.push(relativePath);
+      } else {
+        candidates.push(...absolutePaths);
+      }
+    }
+
+    return candidates
+      .sort((left, right) => left.localeCompare(right))
+      .slice(0, 1500);
   }
 
   private getEnabledTargetSources(
@@ -1229,7 +1379,26 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
       z-index: 100;
     }
 
+    #hashMenu {
+      display: none;
+      position: absolute;
+      bottom: 100%;
+      left: var(--cr-spacing-md);
+      right: var(--cr-spacing-md);
+      background: var(--vscode-editorSuggestWidget-background, var(--vscode-editorWidget-background));
+      border: 1px solid var(--vscode-editorSuggestWidget-border, var(--vscode-editorWidget-border, transparent));
+      border-radius: var(--cr-border-radius);
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+      max-height: 220px;
+      overflow-y: auto;
+      z-index: 100;
+    }
+
     #slashMenu.visible {
+      display: block;
+    }
+
+    #hashMenu.visible {
       display: block;
     }
 
@@ -1262,6 +1431,31 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
       opacity: 0.7;
       font-size: 0.85em;
     }
+
+    .hash-item {
+      display: flex;
+      align-items: center;
+      gap: var(--cr-spacing-sm);
+      padding: var(--cr-spacing-sm) var(--cr-spacing-md);
+      cursor: pointer;
+      font-size: 0.9em;
+    }
+
+    .hash-item:hover,
+    .hash-item.selected {
+      background: var(--vscode-editorSuggestWidget-selectedBackground, var(--vscode-list-activeSelectionBackground));
+      color: var(--vscode-editorSuggestWidget-selectedForeground, var(--vscode-list-activeSelectionForeground));
+    }
+
+    .hash-item .hash-icon {
+      width: 20px;
+      text-align: center;
+      font-weight: 700;
+    }
+
+    .hash-item .hash-label {
+      font-family: var(--vscode-editor-font-family);
+    }
   </style>
 </head>
 <body>
@@ -1270,13 +1464,14 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
       <div class="welcome" id="welcome">
         <h2>ContextRelay</h2>
         <p>Chat with Microsoft 365 Copilot, or search Microsoft 365 context with slash commands.</p>
-        <p style="font-size: 0.8em;">Type <code>/</code> for source search commands. Plain text starts or continues chat.</p>
-        <p style="font-size: 0.8em;">Pin snippets and run <code>/ask</code> to process them with Microsoft 365 Copilot in the panel.</p>
+        <p style="font-size: 0.8em;">Type <code>/</code> for source search commands. Use <code>#path/to/file</code> (or <code>#"path with spaces"</code>) to attach local workspace files to Copilot and /workiq prompts.</p>
+        <p style="font-size: 0.8em;">Pin snippets or mention <code>#files</code>, then run <code>/ask</code> to process that context with Microsoft 365 Copilot in the panel.</p>
       </div>
     </div>
 
     <div id="inputArea">
       <div id="slashMenu" role="listbox" aria-label="Slash commands"></div>
+      <div id="hashMenu" role="listbox" aria-label="Workspace files"></div>
 
       <div id="inputWrapper">
         <textarea
@@ -1285,7 +1480,7 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
           placeholder="Ask Copilot, or type / for source search"
           aria-label="Copilot chat or source search input"
           aria-haspopup="listbox"
-          aria-controls="slashMenu"
+          aria-controls="slashMenu hashMenu"
         ></textarea>
         <button id="sendButton" aria-label="Send message" title="Send">
           <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
@@ -1294,7 +1489,7 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
           </svg>
         </button>
       </div>
-      <div id="inputHint">Press Enter to send • Shift+Enter for new line • Type / for source search commands</div>
+      <div id="inputHint">Press Enter to send • Shift+Enter for new line • Type / for source search commands • Use #file to attach local context</div>
     </div>
   </div>
 

--- a/src/panel/copilotSupportedExtensions.ts
+++ b/src/panel/copilotSupportedExtensions.ts
@@ -1,0 +1,33 @@
+import * as path from 'path';
+
+const COPILOT_SUPPORTED_EXTENSIONS = new Set<string>([
+  '.txt', '.md', '.markdown', '.rst',
+  '.json', '.jsonc', '.yaml', '.yml', '.toml', '.ini', '.xml',
+  '.js', '.mjs', '.cjs', '.ts', '.tsx', '.jsx',
+  '.py', '.java', '.cs', '.cpp', '.c', '.h', '.hpp',
+  '.go', '.rs', '.rb', '.php', '.swift', '.kt', '.kts',
+  '.scala', '.sql', '.sh', '.ps1', '.psm1', '.psd1',
+  '.html', '.htm', '.css', '.scss', '.less',
+  '.vue', '.svelte',
+  '.dockerfile', '.env',
+  '.gitignore', '.gitattributes',
+  '.csv'
+]);
+
+const COPILOT_SUPPORTED_BASENAMES = new Set<string>([
+  'dockerfile',
+  'makefile',
+  'readme',
+  'license'
+]);
+
+export function isCopilotSupportedFileExtension(filePath: string): boolean {
+  const basename = path.basename(filePath).toLowerCase();
+  if (COPILOT_SUPPORTED_BASENAMES.has(basename)) {
+    return true;
+  }
+
+  const extension = path.extname(filePath).toLowerCase();
+  return COPILOT_SUPPORTED_EXTENSIONS.has(extension);
+}
+

--- a/src/panel/copilotSupportedExtensions.ts
+++ b/src/panel/copilotSupportedExtensions.ts
@@ -28,6 +28,10 @@ export function isCopilotSupportedFileExtension(filePath: string): boolean {
   }
 
   const extension = path.extname(filePath).toLowerCase();
+  // path.extname('.env') returns '' — for dotfiles the full basename IS the extension
+  if (extension === '' && basename.startsWith('.')) {
+    return COPILOT_SUPPORTED_EXTENSIONS.has(basename);
+  }
   return COPILOT_SUPPORTED_EXTENSIONS.has(extension);
 }
 

--- a/src/panel/fileMentions.ts
+++ b/src/panel/fileMentions.ts
@@ -1,0 +1,276 @@
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import { pathToFileURL } from 'url';
+import { normalizeExtractedText } from '../textExtraction';
+import { isCopilotSupportedFileExtension } from './copilotSupportedExtensions';
+
+const FILE_MENTION_PATTERN = /(^|\s)#(?:"([^"]+)"|'([^']+)'|([^\s#]+))/g;
+const ONLY_DIGITS_PATTERN = /^\d+$/;
+
+export const MAX_FILE_MENTIONS = 5;
+export const MAX_WORKIQ_FILE_CONTEXT_CHARS = 12_000;
+export const MAX_WORKIQ_FILE_CHARS = 4_000;
+
+export interface FileMentionCandidate {
+  rawPath: string;
+  removeStart: number;
+  removeEnd: number;
+}
+
+export interface ResolvedFileMention {
+  absolutePath: string;
+  workspaceRoot: string;
+  relativePath: string;
+  uri: string;
+}
+
+export interface ResolveFileMentionResult {
+  cleanedPrompt: string;
+  files: ResolvedFileMention[];
+  errors: string[];
+}
+
+interface FileMatch {
+  candidatePath: string;
+  workspaceRoot: string;
+  canonicalPath: string;
+}
+
+export function extractFileMentionCandidates(input: string): FileMentionCandidate[] {
+  const candidates: FileMentionCandidate[] = [];
+  for (const match of input.matchAll(FILE_MENTION_PATTERN)) {
+    const prefix = match[1] ?? '';
+    const rawPath = (match[2] ?? match[3] ?? match[4] ?? '').trim();
+    if (!rawPath || ONLY_DIGITS_PATTERN.test(rawPath)) {
+      continue;
+    }
+
+    const tokenStart = (match.index ?? 0) + prefix.length;
+    const tokenEnd = (match.index ?? 0) + match[0].length;
+    candidates.push({
+      rawPath,
+      removeStart: tokenStart,
+      removeEnd: tokenEnd
+    });
+  }
+
+  return candidates;
+}
+
+export async function resolveFileMentions(
+  input: string,
+  workspaceRoots: readonly string[]
+): Promise<ResolveFileMentionResult> {
+  const candidates = extractFileMentionCandidates(input);
+  if (candidates.length === 0) {
+    return {
+      cleanedPrompt: input.trim(),
+      files: [],
+      errors: []
+    };
+  }
+
+  if (workspaceRoots.length === 0) {
+    return {
+      cleanedPrompt: stripMentionTokens(input, candidates),
+      files: [],
+      errors: ['# file mentions require an opened workspace folder.']
+    };
+  }
+
+  if (candidates.length > MAX_FILE_MENTIONS) {
+    return {
+      cleanedPrompt: stripMentionTokens(input, candidates),
+      files: [],
+      errors: [`You can reference up to ${MAX_FILE_MENTIONS} files per message.`]
+    };
+  }
+
+  const normalizedRoots = await Promise.all(workspaceRoots.map(root => fs.realpath(root)));
+  const files: ResolvedFileMention[] = [];
+  const errors: string[] = [];
+  const seenUris = new Set<string>();
+
+  for (const candidate of candidates) {
+    const match = await resolveSingleMention(candidate.rawPath, normalizedRoots);
+    if (typeof match === 'string') {
+      errors.push(match);
+      continue;
+    }
+
+    const uri = pathToFileURL(match.canonicalPath).toString();
+    if (seenUris.has(uri)) {
+      continue;
+    }
+    seenUris.add(uri);
+
+    files.push({
+      absolutePath: match.canonicalPath,
+      workspaceRoot: match.workspaceRoot,
+      relativePath: toDisplayRelativePath(match.workspaceRoot, match.canonicalPath),
+      uri
+    });
+  }
+
+  return {
+    cleanedPrompt: stripMentionTokens(input, candidates),
+    files,
+    errors
+  };
+}
+
+export async function buildWorkIqPromptWithFiles(
+  prompt: string,
+  files: readonly ResolvedFileMention[]
+): Promise<string> {
+  if (files.length === 0) {
+    return prompt;
+  }
+
+  let remainingBudget = MAX_WORKIQ_FILE_CONTEXT_CHARS;
+  const sections: string[] = [];
+
+  for (const file of files) {
+    if (remainingBudget <= 0) {
+      break;
+    }
+
+    const content = await fs.readFile(file.absolutePath, 'utf8');
+    const normalized = normalizeExtractedText(content);
+    const bounded = truncateForBudget(normalized || '(empty file)', Math.min(MAX_WORKIQ_FILE_CHARS, remainingBudget));
+    if (!bounded.trim()) {
+      continue;
+    }
+
+    sections.push(`[File: ${file.relativePath}]\n${bounded}`);
+    remainingBudget -= bounded.length;
+  }
+
+  if (sections.length === 0) {
+    return prompt;
+  }
+
+  return `${prompt}\n\nContextRelay local file context:\n${sections.join('\n\n')}`;
+}
+
+function stripMentionTokens(input: string, candidates: readonly FileMentionCandidate[]): string {
+  if (candidates.length === 0) {
+    return input.trim();
+  }
+
+  const sorted = [...candidates].sort((left, right) => left.removeStart - right.removeStart);
+  let result = '';
+  let cursor = 0;
+  for (const candidate of sorted) {
+    result += input.slice(cursor, candidate.removeStart);
+    cursor = candidate.removeEnd;
+  }
+  result += input.slice(cursor);
+  return result.replace(/[ \t]{2,}/g, ' ').replace(/\s+\n/g, '\n').replace(/\n\s+/g, '\n').trim();
+}
+
+async function resolveSingleMention(rawPath: string, workspaceRoots: readonly string[]): Promise<FileMatch | string> {
+  const possibleMatches: FileMatch[] = [];
+  const isAbsolute = path.isAbsolute(rawPath);
+
+  if (isAbsolute) {
+    const candidatePath = path.resolve(rawPath);
+    const candidateMatch = await resolveCandidatePath(candidatePath, workspaceRoots);
+    if (typeof candidateMatch === 'string') {
+      return candidateMatch;
+    }
+    possibleMatches.push(candidateMatch);
+  } else {
+    for (const workspaceRoot of workspaceRoots) {
+      const candidatePath = path.resolve(workspaceRoot, rawPath);
+      const candidateMatch = await resolveCandidatePath(candidatePath, workspaceRoots, workspaceRoot);
+      if (typeof candidateMatch === 'string') {
+        continue;
+      }
+      possibleMatches.push(candidateMatch);
+    }
+  }
+
+  if (possibleMatches.length === 0) {
+    return `File not found for #${rawPath}.`;
+  }
+
+  if (!isAbsolute && possibleMatches.length > 1) {
+    return `File path "#${rawPath}" is ambiguous across workspace folders. Use a unique path.`;
+  }
+
+  const selected = possibleMatches[0];
+  if (!isCopilotSupportedFileExtension(selected.canonicalPath)) {
+    return `Unsupported file type for #${rawPath}. Only Copilot-supported file extensions are allowed.`;
+  }
+
+  return selected;
+}
+
+async function resolveCandidatePath(
+  candidatePath: string,
+  workspaceRoots: readonly string[],
+  preferredRoot?: string
+): Promise<FileMatch | string> {
+  const stat = await safeStat(candidatePath);
+  if (!stat || !stat.isFile()) {
+    return `File not found for #${candidatePath}.`;
+  }
+
+  const canonicalPath = await fs.realpath(candidatePath);
+  const workspaceRoot = preferredRoot ?? findContainingWorkspaceRoot(canonicalPath, workspaceRoots);
+  if (!workspaceRoot) {
+    return `File #${candidatePath} is outside the opened workspace.`;
+  }
+
+  if (!isPathWithinRoot(canonicalPath, workspaceRoot)) {
+    return `File #${candidatePath} is outside the opened workspace.`;
+  }
+
+  return {
+    candidatePath,
+    workspaceRoot,
+    canonicalPath
+  };
+}
+
+function findContainingWorkspaceRoot(candidatePath: string, workspaceRoots: readonly string[]): string | undefined {
+  return workspaceRoots.find(root => isPathWithinRoot(candidatePath, root));
+}
+
+function isPathWithinRoot(candidatePath: string, workspaceRoot: string): boolean {
+  const relative = path.relative(workspaceRoot, candidatePath);
+  if (relative === '') {
+    return true;
+  }
+  return !relative.startsWith('..') && !path.isAbsolute(relative);
+}
+
+function toDisplayRelativePath(workspaceRoot: string, absolutePath: string): string {
+  const relative = path.relative(workspaceRoot, absolutePath);
+  return relative.split(path.sep).join('/');
+}
+
+function truncateForBudget(value: string, budget: number): string {
+  if (budget <= 0) {
+    return '';
+  }
+  if (value.length <= budget) {
+    return value;
+  }
+
+  const suffix = `\n[truncated ${value.length - budget} chars]`;
+  if (suffix.length >= budget) {
+    return suffix.slice(0, budget);
+  }
+  return `${value.slice(0, budget - suffix.length)}${suffix}`;
+}
+
+async function safeStat(candidatePath: string): Promise<import('fs').Stats | undefined> {
+  try {
+    return await fs.stat(candidatePath);
+  } catch {
+    return undefined;
+  }
+}
+

--- a/src/panel/types.ts
+++ b/src/panel/types.ts
@@ -109,6 +109,11 @@ export interface PinnedItemsMessage {
   keys: string[];
 }
 
+export interface WorkspaceFilesMessage {
+  command: 'workspaceFiles';
+  files: string[];
+}
+
 export type HostToWebviewMessage =
   | UserMessageDisplay
   | QueryResultMessage
@@ -117,4 +122,5 @@ export type HostToWebviewMessage =
   | SlashHelpMessage
   | ClearChatMessage
   | AssistantMessage
-  | PinnedItemsMessage;
+  | PinnedItemsMessage
+  | WorkspaceFilesMessage;

--- a/src/router/commandRouter.ts
+++ b/src/router/commandRouter.ts
@@ -187,7 +187,7 @@ export function getHelpText(command: string | readonly SearchCommandName[]): str
     planner: 'Example: /task release checklist\nExample: /task metadata comments onboarding',
     task: 'Example: /task release checklist\nExample: /task metadata comments onboarding',
     all: 'Example: /all architecture decisions\nExample: /mail /onedrive architecture decisions\nPlain text without a slash command starts or continues a Microsoft 365 Copilot chat.',
-    ask: 'Example: /ask 日本語に翻訳してmarkdownにして\nExample: /ask Summarize the pinned docs as a bullet list\nPinned snippets are used as context and the Microsoft 365 Copilot response is shown in the panel.',
+    ask: 'Example: /ask 日本語に翻訳してmarkdownにして\nExample: /ask #README.md Summarize this file as a bullet list\nPinned snippets or # file mentions are used as context and the Microsoft 365 Copilot response is shown in the panel.',
     clear: 'Example: /clear\nClears the current chat transcript and discards all pinned snippets.',
     workiq: 'Example: /workiq Summarize my recent emails from Alice\nExample: /workiq What meetings do I have today?\nSends a natural language query to the Work IQ Gateway (A2A protocol). Requires Microsoft 365 Copilot license.'
   };

--- a/src/test/suite/chatContext.test.ts
+++ b/src/test/suite/chatContext.test.ts
@@ -40,6 +40,28 @@ suite('chatContext', () => {
     assert.deepEqual(payload.labels, ['spec.docx', 'plan.docx']);
   });
 
+  test('adds local # mention files before snippet URLs and deduplicates by uri', () => {
+    const payload = buildChatContextPayload({
+      snippets: [
+        snippet('sharepoint', 'spec.docx', 'body', 'file:///workspace/spec.docx')
+      ],
+      localFiles: [
+        { uri: 'file:///workspace/spec.docx', label: 'Local file: spec.docx' },
+        { uri: 'file:///workspace/notes.md', label: 'Local file: notes.md' }
+      ]
+    });
+
+    assert.deepEqual(payload.contextualResources?.files, [
+      { uri: 'file:///workspace/spec.docx' },
+      { uri: 'file:///workspace/notes.md' }
+    ]);
+    assert.deepEqual(payload.labels, [
+      'Local file: spec.docx',
+      'Local file: notes.md',
+      'spec.docx'
+    ]);
+  });
+
   test('uses non-file snippets and visible result as additional context', () => {
     const payload = buildChatContextPayload({
       snippets: [snippet('teams', 'standup', 'Release is blocked by test failures.')],

--- a/src/test/suite/chatViewProvider.test.ts
+++ b/src/test/suite/chatViewProvider.test.ts
@@ -22,6 +22,7 @@ const capturedPayloads: Array<unknown> = [];
 const workIqRequests: Array<{ token: string; query: string; contextId?: string }> = [];
 let replies: string[] = [];
 let workIqReplies: Array<{ text: string; contextId?: string }> = [];
+let workspaceFolders: Array<{ uri: { fsPath: string } }> | undefined;
 
 class InMemoryMemento implements vscode.Memento {
   private readonly store = new Map<string, unknown>();
@@ -60,6 +61,17 @@ function createContext(): vscode.ExtensionContext {
 function createVscodeStub(): typeof vscode {
   return {
     workspace: {
+      get workspaceFolders() {
+        return workspaceFolders as unknown as vscode.WorkspaceFolder[] | undefined;
+      },
+      getWorkspaceFolder: (uri: { fsPath: string }) => {
+        const folders = workspaceFolders ?? [];
+        return folders.find(folder =>
+          uri.fsPath === folder.uri.fsPath ||
+          uri.fsPath.startsWith(`${folder.uri.fsPath}${path.sep}`)
+        ) as unknown as vscode.WorkspaceFolder | undefined;
+      },
+      findFiles: async () => [],
       getConfiguration: () => ({
         get: <T>(key: string, defaultValue: T): T =>
           (configValues.has(key) ? configValues.get(key) : defaultValue) as T
@@ -196,6 +208,7 @@ suite('ChatViewProvider', () => {
       { text: 'Work IQ first answer', contextId: 'ctx-workiq-1' },
       { text: 'Work IQ second answer', contextId: 'ctx-workiq-2' }
     ];
+    workspaceFolders = undefined;
   });
 
   test('loads the webview script via external URI (no blocking file read)', () => {
@@ -235,8 +248,8 @@ suite('ChatViewProvider', () => {
       {} as never
     );
 
-    await (provider as unknown as { handlePlainChat(prompt: string): Promise<void> }).handlePlainChat('first prompt');
-    await (provider as unknown as { handlePlainChat(prompt: string): Promise<void> }).handlePlainChat('follow-up prompt');
+    await (provider as unknown as { handlePlainChat(prompt: string, mentionFiles: unknown[]): Promise<void> }).handlePlainChat('first prompt', []);
+    await (provider as unknown as { handlePlainChat(prompt: string, mentionFiles: unknown[]): Promise<void> }).handlePlainChat('follow-up prompt', []);
 
     assert.equal(capturedPayloads.length, 2);
     assert.equal((capturedPayloads[0] as { additionalContext?: unknown }).additionalContext, undefined);
@@ -258,9 +271,9 @@ suite('ChatViewProvider', () => {
       {} as never
     );
 
-    await (provider as unknown as { handlePlainChat(prompt: string): Promise<void> }).handlePlainChat('first prompt');
+    await (provider as unknown as { handlePlainChat(prompt: string, mentionFiles: unknown[]): Promise<void> }).handlePlainChat('first prompt', []);
     provider.clearChat();
-    await (provider as unknown as { handlePlainChat(prompt: string): Promise<void> }).handlePlainChat('after clear');
+    await (provider as unknown as { handlePlainChat(prompt: string, mentionFiles: unknown[]): Promise<void> }).handlePlainChat('after clear', []);
 
     const secondPayload = capturedPayloads[1] as {
       additionalContext?: Array<{ description: string; text: string }>;
@@ -283,6 +296,32 @@ suite('ChatViewProvider', () => {
     assert.equal(capturedPayloads.length, 0);
     assert.equal(errorMessages.length, 0);
     assert.equal(infoMessages.length, 0);
+  });
+
+  test('/ask with # file mention does not require pinned snippets', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'context-relay-ask-mentions-'));
+    fs.writeFileSync(path.join(root, 'notes.md'), 'ship checklist', 'utf8');
+    workspaceFolders = [{ uri: { fsPath: root } }];
+
+    try {
+      const provider = new ChatViewProvider(
+        createContext(),
+        { getAccessToken: async () => 'token-123' } as never,
+        {} as never
+      );
+
+      await provider.submitQuery('/ask #notes.md summarize this');
+
+      assert.equal(warningMessages.length, 0);
+      assert.equal(capturedPayloads.length, 1);
+      const payload = capturedPayloads[0] as {
+        contextualResources?: { files?: Array<{ uri: string }> };
+      };
+      assert.equal(payload.contextualResources?.files?.length, 1);
+      assert.ok(payload.contextualResources?.files?.[0].uri.startsWith('file:///'));
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
   });
 
   test('/workiq sends query, shows loading, and renders the Work IQ response', async () => {
@@ -331,5 +370,55 @@ suite('ChatViewProvider', () => {
       { token: 'workiq-token', query: 'follow up', contextId: 'ctx-workiq-1' },
       { token: 'workiq-token', query: 'after clear', contextId: undefined }
     ]);
+  });
+
+  test('plain chat attaches #file mentions as Copilot contextual file resources', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'context-relay-chat-mentions-'));
+    fs.writeFileSync(path.join(root, 'notes.md'), 'meeting notes', 'utf8');
+    workspaceFolders = [{ uri: { fsPath: root } }];
+
+    try {
+      const provider = new ChatViewProvider(
+        createContext(),
+        { getAccessToken: async () => 'token-123' } as never,
+        {} as never
+      );
+
+      await provider.submitQuery('Summarize #notes.md');
+
+      const payload = capturedPayloads[0] as {
+        contextualResources?: { files?: Array<{ uri: string }> };
+        labels: string[];
+      };
+      assert.equal(payload.contextualResources?.files?.length, 1);
+      assert.ok(payload.contextualResources?.files?.[0].uri.startsWith('file:///'));
+      assert.ok(payload.labels.some(label => label.includes('Local file: notes.md')));
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('/workiq blocks execution when #file mention is invalid', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'context-relay-workiq-invalid-'));
+    workspaceFolders = [{ uri: { fsPath: root } }];
+
+    try {
+      const provider = new ChatViewProvider(
+        createContext(),
+        { getWorkIqAccessToken: async () => 'workiq-token' } as never,
+        {} as never
+      );
+      const messages: Array<{ command: string; [key: string]: unknown }> = [];
+      (provider as unknown as { postMessage(message: { command: string; [key: string]: unknown }): void }).postMessage = (message) => {
+        messages.push(message);
+      };
+
+      await provider.submitQuery('/workiq summarize #missing.md');
+
+      assert.equal(workIqRequests.length, 0);
+      assert.equal(messages.some(message => message.command === 'queryError'), true);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
   });
 });

--- a/src/test/suite/dependencyVersions.test.ts
+++ b/src/test/suite/dependencyVersions.test.ts
@@ -71,6 +71,19 @@ suite('Dependency security baselines', () => {
     assert.equal(testSecurity, 'npm run security:check', 'test:security must reuse security:check');
   });
 
+  test('pins vsce packaging script to the 3.9.1 baseline or newer', () => {
+    const packageJson = readRepoJson<PackageJson>('package.json');
+    const vsceScript = packageJson.scripts?.['vsce:package'];
+    const versionMatch = vsceScript?.match(/@vscode\/vsce@([0-9]+(?:\.[0-9]+){1,2})/);
+
+    assert.ok(vsceScript, 'vsce:package script must exist');
+    assert.ok(versionMatch?.[1], `vsce:package must pin an explicit @vscode/vsce version (found: ${vsceScript ?? 'missing'})`);
+    assert.ok(
+      compareVersions(versionMatch?.[1], '3.9.1') >= 0,
+      `vsce:package must use @vscode/vsce 3.9.1 or newer (found: ${versionMatch?.[1] ?? 'missing'})`
+    );
+  });
+
   test('uses non-vulnerable @typescript-eslint major versions', () => {
     const packageJson = readRepoJson<PackageJson>('package.json');
 
@@ -99,6 +112,19 @@ suite('Dependency security baselines', () => {
     assert.ok(
       (getMajor(nodeEngine) ?? 0) >= 22,
       `package.json must require Node.js 22 or later when using the supported glob baseline (found: ${nodeEngine ?? 'missing'})`
+    );
+  });
+
+  test('keeps @types/vscode aligned with engines.vscode', () => {
+    const packageJson = readRepoJson<PackageJson>('package.json');
+    const vscodeTypesVersion = packageJson.devDependencies?.['@types/vscode'];
+    const vscodeEngineVersion = packageJson.engines?.vscode;
+
+    assert.ok(vscodeTypesVersion, '@types/vscode must be declared in devDependencies');
+    assert.ok(vscodeEngineVersion, 'engines.vscode must be declared');
+    assert.ok(
+      compareVersions(vscodeEngineVersion, vscodeTypesVersion ?? '') >= 0,
+      `@types/vscode (${vscodeTypesVersion ?? 'missing'}) must not exceed engines.vscode (${vscodeEngineVersion ?? 'missing'})`
     );
   });
 
@@ -195,5 +221,32 @@ suite('Dependency security baselines', () => {
       compareVersions(packageLockJson.packages?.['node_modules/sanitize-html']?.version, '2.17.4') >= 0,
       `installed sanitize-html must stay on a non-vulnerable baseline or newer (found: ${packageLockJson.packages?.['node_modules/sanitize-html']?.version ?? 'missing'})`
     );
+  });
+
+  test('does not install known deprecated transitive packages', () => {
+    const packageLockJson = readRepoJson<PackageLockJson>('package-lock.json');
+    const packageEntries = packageLockJson.packages ?? {};
+
+    const blockedPackages = ['node_modules/whatwg-encoding', 'node_modules/prebuild-install'];
+    for (const packageName of blockedPackages) {
+      assert.equal(
+        packageEntries[packageName],
+        undefined,
+        `${packageName} must not be present in package-lock.json`
+      );
+    }
+
+    const legacyGlobPackage = packageEntries['node_modules/glob'];
+    if (legacyGlobPackage) {
+      assert.ok(
+        compareVersions(legacyGlobPackage.version, '12.0.0') >= 0,
+        `installed glob must be 12.0.0+ (found: ${legacyGlobPackage.version ?? 'missing'})`
+      );
+      assert.equal(
+        legacyGlobPackage.deprecated,
+        undefined,
+        `installed glob must not be deprecated (found: ${legacyGlobPackage.deprecated ?? 'not deprecated'})`
+      );
+    }
   });
 });

--- a/src/test/suite/fileMentions.test.ts
+++ b/src/test/suite/fileMentions.test.ts
@@ -34,6 +34,24 @@ suite('fileMentions', () => {
     }
   });
 
+  test('resolves dotfiles like .env and .gitignore', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'context-relay-dotfile-'));
+    fs.writeFileSync(path.join(root, '.env'), 'SECRET=1', 'utf8');
+    fs.writeFileSync(path.join(root, '.gitignore'), 'node_modules', 'utf8');
+
+    try {
+      const resultEnv = await resolveFileMentions('Check #.env', [root]);
+      assert.equal(resultEnv.errors.length, 0, '.env should be supported');
+      assert.equal(resultEnv.files.length, 1);
+
+      const resultGitignore = await resolveFileMentions('Check #.gitignore', [root]);
+      assert.equal(resultGitignore.errors.length, 0, '.gitignore should be supported');
+      assert.equal(resultGitignore.files.length, 1);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   test('rejects unsupported extensions', async () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), 'context-relay-mentions-'));
     fs.writeFileSync(path.join(root, 'capture.pcap'), 'pcap-binary', 'utf8');

--- a/src/test/suite/fileMentions.test.ts
+++ b/src/test/suite/fileMentions.test.ts
@@ -1,0 +1,66 @@
+import { strict as assert } from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  buildWorkIqPromptWithFiles,
+  extractFileMentionCandidates,
+  resolveFileMentions
+} from '../../panel/fileMentions';
+
+suite('fileMentions', () => {
+  test('extracts # mention candidates and ignores C# and issue refs', () => {
+    const candidates = extractFileMentionCandidates('Use C# for API #123 and read #docs/plan.md and #"notes/release plan.md"');
+    assert.deepEqual(candidates.map(candidate => candidate.rawPath), [
+      'docs/plan.md',
+      'notes/release plan.md'
+    ]);
+  });
+
+  test('resolves workspace-relative files and strips mention tokens from prompt', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'context-relay-mentions-'));
+    fs.mkdirSync(path.join(root, 'docs'), { recursive: true });
+    fs.writeFileSync(path.join(root, 'docs', 'plan.md'), 'Ship checklist', 'utf8');
+
+    try {
+      const result = await resolveFileMentions('Summarize #docs/plan.md for me', [root]);
+      assert.equal(result.errors.length, 0);
+      assert.equal(result.cleanedPrompt, 'Summarize for me');
+      assert.equal(result.files.length, 1);
+      assert.equal(result.files[0].relativePath, 'docs/plan.md');
+      assert.ok(result.files[0].uri.startsWith('file:///'));
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('rejects unsupported extensions', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'context-relay-mentions-'));
+    fs.writeFileSync(path.join(root, 'capture.pcap'), 'pcap-binary', 'utf8');
+
+    try {
+      const result = await resolveFileMentions('Inspect #capture.pcap', [root]);
+      assert.equal(result.files.length, 0);
+      assert.ok(result.errors[0].toLowerCase().includes('unsupported file type'));
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('builds Work IQ prompt with bounded local file sections', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'context-relay-workiq-'));
+    fs.writeFileSync(path.join(root, 'notes.md'), 'line1\nline2', 'utf8');
+
+    try {
+      const resolved = await resolveFileMentions('Summarize #notes.md', [root]);
+      assert.equal(resolved.errors.length, 0);
+      const workIqPrompt = await buildWorkIqPromptWithFiles('Summarize', resolved.files);
+      assert.ok(workIqPrompt.includes('ContextRelay local file context'));
+      assert.ok(workIqPrompt.includes('[File: notes.md]'));
+      assert.ok(workIqPrompt.includes('line1'));
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+

--- a/src/test/suite/manifestConsistency.test.ts
+++ b/src/test/suite/manifestConsistency.test.ts
@@ -30,6 +30,24 @@ interface PackageJson {
   };
 }
 
+interface LaunchJson {
+  configurations?: Array<{
+    name?: string;
+    type?: string;
+    request?: string;
+    args?: string[];
+    preLaunchTask?: string;
+  }>;
+}
+
+interface TasksJson {
+  tasks?: Array<{
+    label?: string;
+    type?: string;
+    script?: string;
+  }>;
+}
+
 suite('Extension manifest consistency', () => {
   const packageJsonPath = path.resolve(__dirname, '../../../../package.json');
   const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8')) as PackageJson;
@@ -76,6 +94,37 @@ suite('Extension manifest consistency', () => {
       compileScript.includes('webpack'),
       'compile script must generate the webpack runtime bundle used by package.json#main'
     );
+  });
+
+  test('debug launch builds the extension bundle before starting', () => {
+    const launchJsonPath = path.resolve(__dirname, '../../../../.vscode/launch.json');
+    const launchJson = JSON.parse(fs.readFileSync(launchJsonPath, 'utf8')) as LaunchJson;
+
+    const debugConfig = launchJson.configurations?.find(config => config.name === 'Run ContextRelay');
+
+    assert.ok(debugConfig, 'launch.json must define a Run ContextRelay debug configuration');
+    assert.equal(debugConfig?.type, 'extensionHost', 'debug configuration must use the extension host');
+    assert.equal(debugConfig?.request, 'launch', 'debug configuration must launch the extension host');
+    assert.ok(
+      debugConfig?.args?.includes('--extensionDevelopmentPath=${workspaceFolder}'),
+      'debug configuration must point the extension host at the workspace'
+    );
+    assert.equal(
+      debugConfig?.preLaunchTask,
+      'npm: compile',
+      'debug configuration must build the extension bundle before launch'
+    );
+  });
+
+  test('debug task exposes npm compile for the launch configuration', () => {
+    const tasksJsonPath = path.resolve(__dirname, '../../../../.vscode/tasks.json');
+    const tasksJson = JSON.parse(fs.readFileSync(tasksJsonPath, 'utf8')) as TasksJson;
+
+    const compileTask = tasksJson.tasks?.find(task => task.label === 'npm: compile');
+
+    assert.ok(compileTask, 'tasks.json must define an npm: compile task');
+    assert.equal(compileTask?.type, 'npm', 'npm: compile task must be an npm task');
+    assert.equal(compileTask?.script, 'compile', 'npm: compile task must invoke the compile script');
   });
 
   test('wires Work IQ logging to the ContextRelay debug channel', () => {

--- a/src/webview/chatRenderer.ts
+++ b/src/webview/chatRenderer.ts
@@ -368,7 +368,15 @@ export class ChatRenderer {
     const comboCode = document.createElement('code');
     comboCode.textContent = '/mail /onedrive';
     commandsHint.appendChild(comboCode);
-    commandsHint.appendChild(document.createTextNode(' for source search. Plain text starts or continues chat.'));
+    commandsHint.appendChild(document.createTextNode(' for source search. Use '));
+    const hashCode = document.createElement('code');
+    hashCode.textContent = '#file';
+    commandsHint.appendChild(hashCode);
+    commandsHint.appendChild(document.createTextNode(' (or quoted paths like '));
+    const quotedHashCode = document.createElement('code');
+    quotedHashCode.textContent = '#"notes/Release Plan.md"';
+    commandsHint.appendChild(quotedHashCode);
+    commandsHint.appendChild(document.createTextNode(') to attach local workspace files to Copilot and /workiq prompts.'));
     welcome.appendChild(commandsHint);
 
     const askHint = document.createElement('p');
@@ -377,7 +385,11 @@ export class ChatRenderer {
     const askCode = document.createElement('code');
     askCode.textContent = '/ask';
     askHint.appendChild(askCode);
-    askHint.appendChild(document.createTextNode(' to process pinned context with Microsoft 365 Copilot.'));
+    askHint.appendChild(document.createTextNode(' to process pinned snippets or '));
+    const hashMentionCode = document.createElement('code');
+    hashMentionCode.textContent = '#file';
+    askHint.appendChild(hashMentionCode);
+    askHint.appendChild(document.createTextNode(' mentions with Microsoft 365 Copilot.'));
     welcome.appendChild(askHint);
 
     this.chatArea.appendChild(welcome);

--- a/src/webview/hashMenu.ts
+++ b/src/webview/hashMenu.ts
@@ -1,0 +1,209 @@
+interface HashSelectionContext {
+  tokenStart: number;
+  tokenEnd: number;
+  partialPath: string;
+}
+
+export class HashMenu {
+  private readonly menu: HTMLElement;
+  private readonly input: HTMLTextAreaElement;
+  private readonly onSelect: (nextValue: string) => void;
+  private allFiles: string[] = [];
+  private filteredFiles: string[] = [];
+  private selectedIndex = -1;
+  private selectionContext?: HashSelectionContext;
+
+  constructor(
+    menuEl: HTMLElement,
+    inputEl: HTMLTextAreaElement,
+    onSelect: (nextValue: string) => void
+  ) {
+    this.menu = menuEl;
+    this.input = inputEl;
+    this.onSelect = onSelect;
+  }
+
+  setFiles(files: readonly string[]): void {
+    this.allFiles = [...files];
+    if (this.selectionContext) {
+      this.update(this.input.value);
+    }
+  }
+
+  update(text: string): boolean {
+    const context = this.getSelectionContext(text);
+    if (!context) {
+      this.hide();
+      return false;
+    }
+
+    this.selectionContext = context;
+    const query = context.partialPath.toLowerCase();
+    this.filteredFiles = this.allFiles
+      .filter(file => file.toLowerCase().includes(query))
+      .slice(0, 50);
+
+    if (this.filteredFiles.length === 0) {
+      this.hide();
+      return false;
+    }
+
+    this.selectedIndex = 0;
+    this.renderItems();
+    this.show();
+    return true;
+  }
+
+  handleKeyDown(e: KeyboardEvent): boolean {
+    if (!this.isVisible()) {
+      return false;
+    }
+
+    switch (e.key) {
+      case 'ArrowDown':
+        e.preventDefault();
+        this.selectedIndex = Math.min(this.selectedIndex + 1, this.filteredFiles.length - 1);
+        this.updateSelection();
+        return true;
+
+      case 'ArrowUp':
+        e.preventDefault();
+        this.selectedIndex = Math.max(this.selectedIndex - 1, 0);
+        this.updateSelection();
+        return true;
+
+      case 'Enter':
+      case 'Tab': {
+        if (this.selectedIndex < 0 || this.selectedIndex >= this.filteredFiles.length) {
+          return false;
+        }
+        e.preventDefault();
+        this.applySelection(this.filteredFiles[this.selectedIndex]);
+        this.hide();
+        return true;
+      }
+
+      case 'Escape':
+        e.preventDefault();
+        this.hide();
+        return true;
+
+      default:
+        return false;
+    }
+  }
+
+  show(): void {
+    this.menu.classList.add('visible');
+  }
+
+  hide(): void {
+    this.menu.classList.remove('visible');
+    this.selectedIndex = -1;
+    this.selectionContext = undefined;
+    this.input.removeAttribute('aria-activedescendant');
+  }
+
+  isVisible(): boolean {
+    return this.menu.classList.contains('visible');
+  }
+
+  private renderItems(): void {
+    this.menu.replaceChildren();
+
+    for (const [index, file] of this.filteredFiles.entries()) {
+      const row = document.createElement('div');
+      row.className = `hash-item${index === this.selectedIndex ? ' selected' : ''}`;
+      row.setAttribute('role', 'option');
+      row.id = `hash-option-${index}`;
+      row.dataset.file = file;
+      row.setAttribute('aria-selected', String(index === this.selectedIndex));
+
+      const icon = document.createElement('span');
+      icon.className = 'hash-icon';
+      icon.textContent = '#';
+      row.appendChild(icon);
+
+      const label = document.createElement('span');
+      label.className = 'hash-label';
+      label.textContent = file;
+      row.appendChild(label);
+
+      this.menu.appendChild(row);
+    }
+
+    this.updateAriaActiveDescendant();
+
+    this.menu.querySelectorAll<HTMLElement>('.hash-item').forEach(el => {
+      el.addEventListener('click', () => {
+        const file = el.dataset.file;
+        if (!file) {
+          return;
+        }
+
+        this.applySelection(file);
+        this.hide();
+      });
+    });
+  }
+
+  private updateSelection(): void {
+    const items = this.menu.querySelectorAll<HTMLElement>('.hash-item');
+    items.forEach((el, index) => {
+      el.classList.toggle('selected', index === this.selectedIndex);
+      el.setAttribute('aria-selected', String(index === this.selectedIndex));
+    });
+    this.updateAriaActiveDescendant();
+    items[this.selectedIndex]?.scrollIntoView({ block: 'nearest' });
+  }
+
+  private updateAriaActiveDescendant(): void {
+    if (this.selectedIndex >= 0) {
+      this.input.setAttribute('aria-activedescendant', `hash-option-${this.selectedIndex}`);
+    } else {
+      this.input.removeAttribute('aria-activedescendant');
+    }
+  }
+
+  private applySelection(file: string): void {
+    if (!this.selectionContext) {
+      return;
+    }
+
+    const fileToken = file.includes(' ') ? `#\"${file}\"` : `#${file}`;
+    const prefix = this.input.value.slice(0, this.selectionContext.tokenStart);
+    const suffix = this.input.value.slice(this.selectionContext.tokenEnd);
+    const separator = suffix.startsWith(' ') || suffix.length === 0 ? '' : ' ';
+    this.onSelect(`${prefix}${fileToken}${separator}${suffix}`);
+  }
+
+  private getSelectionContext(text: string): HashSelectionContext | undefined {
+    if (/\s$/.test(text)) {
+      return undefined;
+    }
+
+    const tokenMatch = text.match(/(^|\s)(#(?:"[^"]*|'[^']*|[^\s#]*))$/);
+    if (!tokenMatch) {
+      return undefined;
+    }
+
+    const fullMatch = tokenMatch[0];
+    const prefix = tokenMatch[1] ?? '';
+    const token = tokenMatch[2] ?? '';
+    if (!token.startsWith('#')) {
+      return undefined;
+    }
+
+    const tokenStart = text.length - fullMatch.length + prefix.length;
+    const tokenEnd = text.length;
+    const rawPath = token.slice(1);
+    const partialPath = rawPath.replace(/^["']/, '');
+
+    return {
+      tokenStart,
+      tokenEnd,
+      partialPath
+    };
+  }
+}
+

--- a/src/webview/main.ts
+++ b/src/webview/main.ts
@@ -8,6 +8,7 @@
  */
 
 import { SlashMenu } from './slashMenu';
+import { HashMenu } from './hashMenu';
 import { ChatRenderer } from './chatRenderer';
 
 // Acquire the VS Code API (available in webview context)
@@ -24,6 +25,7 @@ const chatArea = document.getElementById('chatArea')!;
 const promptInput = document.getElementById('promptInput') as HTMLTextAreaElement;
 const sendButton = document.getElementById('sendButton') as HTMLButtonElement;
 const slashMenuEl = document.getElementById('slashMenu')!;
+const hashMenuEl = document.getElementById('hashMenu')!;
 
 // --- Modules ---
 const renderer = new ChatRenderer(chatArea, vscode);
@@ -33,7 +35,15 @@ let hasPendingSubmission = false;
 const slashMenu = new SlashMenu(slashMenuEl, promptInput, (nextValue: string) => {
   promptInput.value = nextValue;
   promptInput.focus();
+  autoResizeInput();
   slashMenu.hide();
+});
+
+const hashMenu = new HashMenu(hashMenuEl, promptInput, (nextValue: string) => {
+  promptInput.value = nextValue;
+  promptInput.focus();
+  autoResizeInput();
+  hashMenu.hide();
 });
 
 // --- Input handling ---
@@ -54,6 +64,7 @@ function submitQuery(): void {
   promptInput.value = '';
   autoResizeInput();
   slashMenu.hide();
+  hashMenu.hide();
 }
 
 function autoResizeInput(): void {
@@ -89,7 +100,11 @@ promptInput.addEventListener('keydown', (e) => {
     return;
   }
 
-  // Let slash menu handle navigation keys first
+  // Let hash/slash menus handle navigation keys first
+  if (hashMenu.handleKeyDown(e)) {
+    return;
+  }
+
   if (slashMenu.handleKeyDown(e)) {
     return;
   }
@@ -105,14 +120,21 @@ promptInput.addEventListener('keydown', (e) => {
 // Input changes — update slash menu and auto-resize
 promptInput.addEventListener('input', () => {
   autoResizeInput();
+  const hashVisible = hashMenu.update(promptInput.value);
+  if (hashVisible) {
+    slashMenu.hide();
+    return;
+  }
+
   slashMenu.update(promptInput.value);
 });
 
-// Close slash menu when clicking outside
+// Close menus when clicking outside
 document.addEventListener('click', (e) => {
   const target = e.target as HTMLElement;
-  if (!slashMenuEl.contains(target) && target !== promptInput) {
+  if (!slashMenuEl.contains(target) && !hashMenuEl.contains(target) && target !== promptInput) {
     slashMenu.hide();
+    hashMenu.hide();
   }
 });
 
@@ -204,6 +226,10 @@ window.addEventListener('message', (event) => {
 
     case 'pinnedItems':
       renderer.setPinnedItems((message.keys as string[]) ?? []);
+      break;
+
+    case 'workspaceFiles':
+      hashMenu.setFiles((message.files as string[]) ?? []);
       break;
   }
 });


### PR DESCRIPTION
Fixes #93.

This fixes the reported `#` mention workflow breakage in the chat panel: typing `#` now opens a folder-aware workspace picker, and `/ask #file ...` remains valid even without pinned snippets.

## What changed
- Added folder-aware `workspaceFiles` entries from the extension host to the webview.
- Updated the `#` menu to show a visible bare-`#` picker, folders first, folder drill-down, typed path search, keyboard/mouse selection, and empty states.
- Kept host-side mention validation authoritative for unsupported, missing, or outside-workspace files.
- Updated help/welcome copy to describe browsing local files with `#`.

## Tests
- `npm run compile`
- `npm run lint`
- `npm test`
- `npm run security:check`