### PR TITLE
chore(deps): consolidate Dependabot pull requests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,30 +1,30 @@
 {
   "name": "context-relay",
-  "version": "0.1.5",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "context-relay",
-      "version": "0.1.5",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "jszip": "^3.10.1",
-        "marked": "^18.0.3",
+        "marked": "^18.0.4",
         "sanitize-html": "^2.17.4"
       },
       "devDependencies": {
         "@types/mocha": "^10.0.10",
-        "@types/node": "^25.8.0",
+        "@types/node": "^25.9.0",
         "@types/sanitize-html": "^2.16.1",
         "@types/vscode": "^1.120.0",
-        "@typescript-eslint/eslint-plugin": "^8.59.3",
-        "@typescript-eslint/parser": "^8.59.3",
+        "@typescript-eslint/eslint-plugin": "^8.59.4",
+        "@typescript-eslint/parser": "^8.59.4",
         "@vscode/test-electron": "^2.5.2",
         "concurrently": "^9.2.1",
         "esbuild": "^0.28.0",
         "eslint": "^10.4.0",
-        "mocha": "11.7.5",
+        "mocha": "11.7.6",
         "ts-loader": "^9.5.7",
         "typescript": "^6.0.3",
         "webpack": "^5.106.2",
@@ -758,9 +758,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.8.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.8.0.tgz",
-      "integrity": "sha512-TCFSk8IZh+iLX1xtksoBVtdmgL+1IX0fC9BeU4QqFSuNdN/K+HUlhqOzEmSYYpZUVsLYcPqc9KX+60iDuninSQ==",
+      "version": "25.9.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.0.tgz",
+      "integrity": "sha512-AOQwYUNolgy3VosiRqXrACUXTN8nJUtPl7FJXMqZVyxiiCLhQuG3jXKvCS1ALr+Y2OmZhzzLVlYPEqJaiqkaJQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -785,17 +785,17 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.59.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.3.tgz",
-      "integrity": "sha512-PwFvSKsXGShKGW6n5bZOhGHEcCZXM8HofLK9fNsEwZXzFRjoY+XT1Vsf1zgyXdwTr0ZYz1/2tkZ0DBTT9jZjhw==",
+      "version": "8.59.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.4.tgz",
+      "integrity": "sha512-PegsU+XfyJJNjd4+u/k6f9yTyp0lEXXiPopUNobZcIAUJFGICFLN+sP0Rb3JehVmiij1Ph0dFGYqODoRo/2+6A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.59.3",
-        "@typescript-eslint/type-utils": "8.59.3",
-        "@typescript-eslint/utils": "8.59.3",
-        "@typescript-eslint/visitor-keys": "8.59.3",
+        "@typescript-eslint/scope-manager": "8.59.4",
+        "@typescript-eslint/type-utils": "8.59.4",
+        "@typescript-eslint/utils": "8.59.4",
+        "@typescript-eslint/visitor-keys": "8.59.4",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -808,22 +808,22 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.59.3",
+        "@typescript-eslint/parser": "^8.59.4",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.59.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.3.tgz",
-      "integrity": "sha512-HPwA+hVkfcriajbNvTmZv4VRauibay+cWArYUYq7u7W7PmGShMxbPxLvrwDme55a6d5alG3nrYfhyJ/G28XlLg==",
+      "version": "8.59.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.4.tgz",
+      "integrity": "sha512-zORHqO/tuhxY1zWuTvMUqddRxpiFJ72xVfcNoWpqdLjs6lfPbuQBJuW4pk+49/uBMy7Ssr4bzgjiKmmDB1UbZQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.59.3",
-        "@typescript-eslint/types": "8.59.3",
-        "@typescript-eslint/typescript-estree": "8.59.3",
-        "@typescript-eslint/visitor-keys": "8.59.3",
+        "@typescript-eslint/scope-manager": "8.59.4",
+        "@typescript-eslint/types": "8.59.4",
+        "@typescript-eslint/typescript-estree": "8.59.4",
+        "@typescript-eslint/visitor-keys": "8.59.4",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -839,14 +839,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.59.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.3.tgz",
-      "integrity": "sha512-ECiUWa/KYRGDFUqTNehaRgzDshnJfkTABJxVemHk4ko22gcr0ukloKjWvyQ64g8YCV/UI47kN1dbmjf/GaQYng==",
+      "version": "8.59.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.4.tgz",
+      "integrity": "sha512-Ly00Vu4oAacfDeHp2Zg85ioNG6l8HG+tN1D7J+xTHSxu9y0awYKJ2zH1rFBn8ZSfuGK+7FxK3Cgl3uAz0aZZLg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.59.3",
-        "@typescript-eslint/types": "^8.59.3",
+        "@typescript-eslint/tsconfig-utils": "^8.59.4",
+        "@typescript-eslint/types": "^8.59.4",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -861,14 +861,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.59.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.3.tgz",
-      "integrity": "sha512-t2LvZnoEfzKtnPjgeEu41xw5gxq9mQVfYy4OoZ4Vlt0sk3JwxmhCca/AR7DwOiHrjWgjAj6as4AhRLKSDfvZIA==",
+      "version": "8.59.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.4.tgz",
+      "integrity": "sha512-mUeR/3H1WrTAddJrwut8OoPjfauaztMQmRwV5fQTUyNVJCLiUXXe4lGEyYIL2oFDpP7UtgbGJXCt72wT0z2S3Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.59.3",
-        "@typescript-eslint/visitor-keys": "8.59.3"
+        "@typescript-eslint/types": "8.59.4",
+        "@typescript-eslint/visitor-keys": "8.59.4"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -879,9 +879,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.59.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.3.tgz",
-      "integrity": "sha512-PcIJHjmaREXLgIAIzLnSY9VucEzz8FKXsRgFa1DmdGCK/5tJpW03TKJF01Q6VZd1lLdz2sIKPWaDUZN9dp//dw==",
+      "version": "8.59.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.4.tgz",
+      "integrity": "sha512-DLCpnKgD4alVxTBSKulK+gU1KCqOgUXfDRDXh2mZgzokQKa/70ax93I2uVO3m/LLvIAtWZIFoiifudmIqAxpMA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -896,15 +896,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.59.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.3.tgz",
-      "integrity": "sha512-g71d8QD8UaiHGvrJwyIS1hCX5r63w6Jll+4VEYhEAHXTDIqX1JgxhTAbEHtKntL9kuc4jRo7/GWw5xfCepSccQ==",
+      "version": "8.59.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.4.tgz",
+      "integrity": "sha512-uonTuPAAKr9XaBGqJ3LjYTh72zy5DyGesljO9gtmk/eFW0W1fRHjnwVYKB35Lm8d5Q5CluEW3gPHjTvZTmgrfA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.59.3",
-        "@typescript-eslint/typescript-estree": "8.59.3",
-        "@typescript-eslint/utils": "8.59.3",
+        "@typescript-eslint/types": "8.59.4",
+        "@typescript-eslint/typescript-estree": "8.59.4",
+        "@typescript-eslint/utils": "8.59.4",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -921,9 +921,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.59.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.3.tgz",
-      "integrity": "sha512-ePFoH0g4ludssdRFqqDxQePCxU4WQyRa9+XVwjm7yLn0FKhMeoetC+qBEEI1Eyb1pGSDveTIT09Bvw2WhlGayg==",
+      "version": "8.59.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.4.tgz",
+      "integrity": "sha512-F1o7WJcCq+bc8dwcO/YsSEOudAH8RDtaOhM6wcAQhcUsFhnWQl81JKy48q1hoxAU0qrzM89+31GYh1515Zde3Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -935,16 +935,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.59.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.3.tgz",
-      "integrity": "sha512-CbRjVRAf7Lr9Kr8RopKcbY45p2VfmmHrm0ygOCYFi7oU8q19m0Fs/6iHS7kNOmwpp+ob07ZVcAqlxUod9lYdmg==",
+      "version": "8.59.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.4.tgz",
+      "integrity": "sha512-F+RuOmcDXo4+TPdfd/TCLS3m2nw8gE9XXyZLrA3JBfaA5tz9TtdkyD3YJFmPxulyc2cKbEok/CvFE3MgSLWnag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.59.3",
-        "@typescript-eslint/tsconfig-utils": "8.59.3",
-        "@typescript-eslint/types": "8.59.3",
-        "@typescript-eslint/visitor-keys": "8.59.3",
+        "@typescript-eslint/project-service": "8.59.4",
+        "@typescript-eslint/tsconfig-utils": "8.59.4",
+        "@typescript-eslint/types": "8.59.4",
+        "@typescript-eslint/visitor-keys": "8.59.4",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -963,16 +963,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.59.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.3.tgz",
-      "integrity": "sha512-JAvT14goBzRzzzZyqq3P9BLArIxTtQURUtFgQ/V7FO+eU+Gg6ES+5ymOPP1wRxXcxAYeivCk4uS3jCKWI1K8Zg==",
+      "version": "8.59.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.4.tgz",
+      "integrity": "sha512-cYXeNAUsG4lJo5dbc1FcKm+JwIWrj1/UpTORsC6tGMjEZ81DYcvIr9/ueikhMa/Y/gDQYGp+YX9/xQrXje5BJw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.59.3",
-        "@typescript-eslint/types": "8.59.3",
-        "@typescript-eslint/typescript-estree": "8.59.3"
+        "@typescript-eslint/scope-manager": "8.59.4",
+        "@typescript-eslint/types": "8.59.4",
+        "@typescript-eslint/typescript-estree": "8.59.4"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -987,13 +987,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.59.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.3.tgz",
-      "integrity": "sha512-f1UQF7ggd42YiwI5wGrRaPsa+P0CINBlrkLPmGfpq/u/I/oVtecoEIfFR9ag/oa1sLOsRNZ6xehf6qMZhQGBDg==",
+      "version": "8.59.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.4.tgz",
+      "integrity": "sha512-U3gxVaDVnuZKhSspW/MzMxE1kq7zOdc072FcSNoqA1I9p8HyKbBFfEHoWckBAMgNMph4MamwS5iTVzFmrnt8TQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.59.3",
+        "@typescript-eslint/types": "8.59.4",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -1374,9 +1374,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2869,9 +2869,9 @@
       }
     },
     "node_modules/marked": {
-      "version": "18.0.3",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.3.tgz",
-      "integrity": "sha512-7VT90JOkDeaRWpfjOReRGPEKn0ecdARBkDGL+tT1wZY0efPPqkUxLUSmzy/C7TIylQYJC9STISEsCHrqb/7VIA==",
+      "version": "18.0.4",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.4.tgz",
+      "integrity": "sha512-c/BTaKzg0G6ezQx97DAkYU7k0HM6ys0FqYeKBL6hlBByZwy+ycA1+f0vDdjMHKKeEjdgkx0GOv9Il6D+85cOqA==",
       "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"
@@ -2951,9 +2951,9 @@
       }
     },
     "node_modules/mocha": {
-      "version": "11.7.5",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.7.5.tgz",
-      "integrity": "sha512-mTT6RgopEYABzXWFx+GcJ+ZQ32kp4fMf0xvpZIIfSq9Z8lC/++MtcCnQ9t5FP2veYEP95FIYSvW+U9fV4xrlig==",
+      "version": "11.7.6",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.7.6.tgz",
+      "integrity": "sha512-nS9xOGbw2I3cjCpxwZAEJ9xK9lmJ08vEkQvLtz4du9ZrF9UrjRpeJGiIgl2Z+Qs++pmB4ecDe48Fwsh+j+j7xA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2985,23 +2985,6 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/mocha/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/mocha/node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/mocha/node_modules/minimatch": {

--- a/package.json
+++ b/package.json
@@ -269,7 +269,8 @@
     "flatted": "3.4.2",
     "serialize-javascript": "7.0.5",
     "glob": "12.0.0",
-    "diff": "8.0.4"
+    "diff": "8.0.4",
+    "brace-expansion": "5.0.6"
   },
   "scripts": {
     "vscode:prepublish": "npm run package",
@@ -294,16 +295,16 @@
   },
   "devDependencies": {
     "@types/mocha": "^10.0.10",
-    "@types/node": "^25.8.0",
+    "@types/node": "^25.9.0",
     "@types/sanitize-html": "^2.16.1",
     "@types/vscode": "^1.120.0",
-    "@typescript-eslint/eslint-plugin": "^8.59.3",
-    "@typescript-eslint/parser": "^8.59.3",
+    "@typescript-eslint/eslint-plugin": "^8.59.4",
+    "@typescript-eslint/parser": "^8.59.4",
     "@vscode/test-electron": "^2.5.2",
     "concurrently": "^9.2.1",
     "esbuild": "^0.28.0",
     "eslint": "^10.4.0",
-    "mocha": "11.7.5",
+    "mocha": "11.7.6",
     "ts-loader": "^9.5.7",
     "typescript": "^6.0.3",
     "webpack": "^5.106.2",
@@ -311,7 +312,7 @@
   },
   "dependencies": {
     "jszip": "^3.10.1",
-    "marked": "^18.0.3",
+    "marked": "^18.0.4",
     "sanitize-html": "^2.17.4"
   }
 }

--- a/src/test/suite/dependencyVersions.test.ts
+++ b/src/test/suite/dependencyVersions.test.ts
@@ -107,36 +107,48 @@ suite('Dependency security baselines', () => {
   test('pins the consolidated Dependabot package.json baselines', () => {
     const packageJson = readRepoJson<PackageJson>('package.json');
 
-    assert.equal(
-      packageJson.dependencies?.marked,
-      '^18.0.4',
-      `marked must stay aligned with the consolidated Dependabot update (found: ${packageJson.dependencies?.marked ?? 'missing'})`
-    );
-    assert.equal(
-      packageJson.devDependencies?.mocha,
-      '11.7.6',
-      `mocha must stay aligned with the consolidated Dependabot update (found: ${packageJson.devDependencies?.mocha ?? 'missing'})`
-    );
-    assert.equal(
-      packageJson.devDependencies?.['@types/node'],
-      '^25.9.0',
-      `@types/node must stay aligned with the consolidated Dependabot update (found: ${packageJson.devDependencies?.['@types/node'] ?? 'missing'})`
-    );
-    assert.equal(
-      packageJson.devDependencies?.['@typescript-eslint/eslint-plugin'],
-      '^8.59.4',
-      `@typescript-eslint/eslint-plugin must stay aligned with the consolidated Dependabot update (found: ${packageJson.devDependencies?.['@typescript-eslint/eslint-plugin'] ?? 'missing'})`
-    );
-    assert.equal(
-      packageJson.devDependencies?.['@typescript-eslint/parser'],
-      '^8.59.4',
-      `@typescript-eslint/parser must stay aligned with the consolidated Dependabot update (found: ${packageJson.devDependencies?.['@typescript-eslint/parser'] ?? 'missing'})`
-    );
-    assert.equal(
-      packageJson.overrides?.['brace-expansion'],
-      '5.0.6',
-      `brace-expansion override must stay on the audited non-vulnerable release (found: ${packageJson.overrides?.['brace-expansion'] ?? 'missing'})`
-    );
+    const expectedBaselines = [
+      {
+        label: 'marked',
+        actual: packageJson.dependencies?.marked,
+        expected: '^18.0.4',
+        message: 'must stay aligned with the consolidated Dependabot update'
+      },
+      {
+        label: 'mocha',
+        actual: packageJson.devDependencies?.mocha,
+        expected: '11.7.6',
+        message: 'must stay aligned with the consolidated Dependabot update'
+      },
+      {
+        label: '@types/node',
+        actual: packageJson.devDependencies?.['@types/node'],
+        expected: '^25.9.0',
+        message: 'must stay aligned with the consolidated Dependabot update'
+      },
+      {
+        label: '@typescript-eslint/eslint-plugin',
+        actual: packageJson.devDependencies?.['@typescript-eslint/eslint-plugin'],
+        expected: '^8.59.4',
+        message: 'must stay aligned with the consolidated Dependabot update'
+      },
+      {
+        label: '@typescript-eslint/parser',
+        actual: packageJson.devDependencies?.['@typescript-eslint/parser'],
+        expected: '^8.59.4',
+        message: 'must stay aligned with the consolidated Dependabot update'
+      },
+      {
+        label: 'brace-expansion override',
+        actual: packageJson.overrides?.['brace-expansion'],
+        expected: '5.0.6',
+        message: 'must stay on the audited non-vulnerable release'
+      }
+    ];
+
+    for (const { label, actual, expected, message } of expectedBaselines) {
+      assert.equal(actual, expected, `${label} ${message} (found: ${actual ?? 'missing'})`);
+    }
   });
 
   test('declares Node 22+ for the supported glob baseline', () => {
@@ -261,36 +273,48 @@ suite('Dependency security baselines', () => {
   test('locks the consolidated Dependabot package versions in package-lock.json', () => {
     const packageLockJson = readRepoJson<PackageLockJson>('package-lock.json');
 
-    assert.equal(
-      packageLockJson.packages?.['node_modules/marked']?.version,
-      '18.0.4',
-      `installed marked must stay aligned with the consolidated Dependabot update (found: ${packageLockJson.packages?.['node_modules/marked']?.version ?? 'missing'})`
-    );
-    assert.equal(
-      packageLockJson.packages?.['node_modules/mocha']?.version,
-      '11.7.6',
-      `installed mocha must stay aligned with the consolidated Dependabot update (found: ${packageLockJson.packages?.['node_modules/mocha']?.version ?? 'missing'})`
-    );
-    assert.equal(
-      packageLockJson.packages?.['node_modules/@types/node']?.version,
-      '25.9.0',
-      `installed @types/node must stay aligned with the consolidated Dependabot update (found: ${packageLockJson.packages?.['node_modules/@types/node']?.version ?? 'missing'})`
-    );
-    assert.equal(
-      packageLockJson.packages?.['node_modules/@typescript-eslint/eslint-plugin']?.version,
-      '8.59.4',
-      `installed @typescript-eslint/eslint-plugin must stay aligned with the consolidated Dependabot update (found: ${packageLockJson.packages?.['node_modules/@typescript-eslint/eslint-plugin']?.version ?? 'missing'})`
-    );
-    assert.equal(
-      packageLockJson.packages?.['node_modules/@typescript-eslint/parser']?.version,
-      '8.59.4',
-      `installed @typescript-eslint/parser must stay aligned with the consolidated Dependabot update (found: ${packageLockJson.packages?.['node_modules/@typescript-eslint/parser']?.version ?? 'missing'})`
-    );
-    assert.equal(
-      packageLockJson.packages?.['node_modules/brace-expansion']?.version,
-      '5.0.6',
-      `installed brace-expansion must stay on the audited non-vulnerable release (found: ${packageLockJson.packages?.['node_modules/brace-expansion']?.version ?? 'missing'})`
-    );
+    const expectedLockfileVersions = [
+      {
+        label: 'installed marked',
+        actual: packageLockJson.packages?.['node_modules/marked']?.version,
+        expected: '18.0.4',
+        message: 'must stay aligned with the consolidated Dependabot update'
+      },
+      {
+        label: 'installed mocha',
+        actual: packageLockJson.packages?.['node_modules/mocha']?.version,
+        expected: '11.7.6',
+        message: 'must stay aligned with the consolidated Dependabot update'
+      },
+      {
+        label: 'installed @types/node',
+        actual: packageLockJson.packages?.['node_modules/@types/node']?.version,
+        expected: '25.9.0',
+        message: 'must stay aligned with the consolidated Dependabot update'
+      },
+      {
+        label: 'installed @typescript-eslint/eslint-plugin',
+        actual: packageLockJson.packages?.['node_modules/@typescript-eslint/eslint-plugin']?.version,
+        expected: '8.59.4',
+        message: 'must stay aligned with the consolidated Dependabot update'
+      },
+      {
+        label: 'installed @typescript-eslint/parser',
+        actual: packageLockJson.packages?.['node_modules/@typescript-eslint/parser']?.version,
+        expected: '8.59.4',
+        message: 'must stay aligned with the consolidated Dependabot update'
+      },
+      {
+        label: 'installed brace-expansion',
+        actual: packageLockJson.packages?.['node_modules/brace-expansion']?.version,
+        expected: '5.0.6',
+        message: 'must stay on the audited non-vulnerable release'
+      }
+    ];
+
+    for (const { label, actual, expected, message } of expectedLockfileVersions) {
+      assert.equal(actual, expected, `${label} ${message} (found: ${actual ?? 'missing'})`);
+    }
     assert.equal(
       packageLockJson.packages?.['node_modules/brace-expansion']?.deprecated,
       undefined,

--- a/src/test/suite/dependencyVersions.test.ts
+++ b/src/test/suite/dependencyVersions.test.ts
@@ -104,6 +104,41 @@ suite('Dependency security baselines', () => {
     );
   });
 
+  test('pins the consolidated Dependabot package.json baselines', () => {
+    const packageJson = readRepoJson<PackageJson>('package.json');
+
+    assert.equal(
+      packageJson.dependencies?.marked,
+      '^18.0.4',
+      `marked must stay aligned with the consolidated Dependabot update (found: ${packageJson.dependencies?.marked ?? 'missing'})`
+    );
+    assert.equal(
+      packageJson.devDependencies?.mocha,
+      '11.7.6',
+      `mocha must stay aligned with the consolidated Dependabot update (found: ${packageJson.devDependencies?.mocha ?? 'missing'})`
+    );
+    assert.equal(
+      packageJson.devDependencies?.['@types/node'],
+      '^25.9.0',
+      `@types/node must stay aligned with the consolidated Dependabot update (found: ${packageJson.devDependencies?.['@types/node'] ?? 'missing'})`
+    );
+    assert.equal(
+      packageJson.devDependencies?.['@typescript-eslint/eslint-plugin'],
+      '^8.59.4',
+      `@typescript-eslint/eslint-plugin must stay aligned with the consolidated Dependabot update (found: ${packageJson.devDependencies?.['@typescript-eslint/eslint-plugin'] ?? 'missing'})`
+    );
+    assert.equal(
+      packageJson.devDependencies?.['@typescript-eslint/parser'],
+      '^8.59.4',
+      `@typescript-eslint/parser must stay aligned with the consolidated Dependabot update (found: ${packageJson.devDependencies?.['@typescript-eslint/parser'] ?? 'missing'})`
+    );
+    assert.equal(
+      packageJson.overrides?.['brace-expansion'],
+      '5.0.6',
+      `brace-expansion override must stay on the audited non-vulnerable release (found: ${packageJson.overrides?.['brace-expansion'] ?? 'missing'})`
+    );
+  });
+
   test('declares Node 22+ for the supported glob baseline', () => {
     const packageJson = readRepoJson<PackageJson>('package.json');
     const nodeEngine = packageJson.engines?.node;
@@ -220,6 +255,46 @@ suite('Dependency security baselines', () => {
     assert.ok(
       compareVersions(packageLockJson.packages?.['node_modules/sanitize-html']?.version, '2.17.4') >= 0,
       `installed sanitize-html must stay on a non-vulnerable baseline or newer (found: ${packageLockJson.packages?.['node_modules/sanitize-html']?.version ?? 'missing'})`
+    );
+  });
+
+  test('locks the consolidated Dependabot package versions in package-lock.json', () => {
+    const packageLockJson = readRepoJson<PackageLockJson>('package-lock.json');
+
+    assert.equal(
+      packageLockJson.packages?.['node_modules/marked']?.version,
+      '18.0.4',
+      `installed marked must stay aligned with the consolidated Dependabot update (found: ${packageLockJson.packages?.['node_modules/marked']?.version ?? 'missing'})`
+    );
+    assert.equal(
+      packageLockJson.packages?.['node_modules/mocha']?.version,
+      '11.7.6',
+      `installed mocha must stay aligned with the consolidated Dependabot update (found: ${packageLockJson.packages?.['node_modules/mocha']?.version ?? 'missing'})`
+    );
+    assert.equal(
+      packageLockJson.packages?.['node_modules/@types/node']?.version,
+      '25.9.0',
+      `installed @types/node must stay aligned with the consolidated Dependabot update (found: ${packageLockJson.packages?.['node_modules/@types/node']?.version ?? 'missing'})`
+    );
+    assert.equal(
+      packageLockJson.packages?.['node_modules/@typescript-eslint/eslint-plugin']?.version,
+      '8.59.4',
+      `installed @typescript-eslint/eslint-plugin must stay aligned with the consolidated Dependabot update (found: ${packageLockJson.packages?.['node_modules/@typescript-eslint/eslint-plugin']?.version ?? 'missing'})`
+    );
+    assert.equal(
+      packageLockJson.packages?.['node_modules/@typescript-eslint/parser']?.version,
+      '8.59.4',
+      `installed @typescript-eslint/parser must stay aligned with the consolidated Dependabot update (found: ${packageLockJson.packages?.['node_modules/@typescript-eslint/parser']?.version ?? 'missing'})`
+    );
+    assert.equal(
+      packageLockJson.packages?.['node_modules/brace-expansion']?.version,
+      '5.0.6',
+      `installed brace-expansion must stay on the audited non-vulnerable release (found: ${packageLockJson.packages?.['node_modules/brace-expansion']?.version ?? 'missing'})`
+    );
+    assert.equal(
+      packageLockJson.packages?.['node_modules/brace-expansion']?.deprecated,
+      undefined,
+      `installed brace-expansion must not be deprecated (found: ${packageLockJson.packages?.['node_modules/brace-expansion']?.deprecated ?? 'not deprecated'})`
     );
   });
 


### PR DESCRIPTION
## Summary
- consolidate the currently open Dependabot dependency bumps into one change
- keep the requested package versions from the superseded Dependabot pull requests
- add a `brace-expansion` override and dependency guard coverage to preserve a zero-vulnerability baseline

## Updated packages
- `@types/node`: `^25.8.0` -> `^25.9.0`
- `@typescript-eslint/eslint-plugin`: `^8.59.3` -> `^8.59.4`
- `@typescript-eslint/parser`: `^8.59.3` -> `^8.59.4`
- `marked`: `^18.0.3` -> `^18.0.4`
- `mocha`: `11.7.5` -> `11.7.6`
- `brace-expansion` override: `5.0.6`

## Tests
- extend `src/test/suite/dependencyVersions.test.ts` to pin the consolidated package baselines in `package.json`
- extend `src/test/suite/dependencyVersions.test.ts` to pin the installed lockfile versions, including the `brace-expansion` security override

Closes #101

Supersedes #96, #97, #98, #99, and #100.