### PR TITLE
feat: derive extension version from git tags

### DIFF
--- a/.github/workflows/release-vsix.yml
+++ b/.github/workflows/release-vsix.yml
@@ -3,7 +3,7 @@ name: Release VSIX
 on:
   push:
     tags:
-      - '*'
+      - 'v*.*.*'
 
 permissions:
   contents: write
@@ -41,6 +41,23 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Sync extension version from pushed tag
+        id: version
+        shell: bash
+        run: node scripts/tag-version.cjs --apply --require-env --write-github-output
+
+      - name: Verify package.json matches the tag version
+        shell: bash
+        env:
+          EXPECTED_VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          ACTUAL_VERSION="$(node -p "require('./package.json').version")"
+          if [ "${ACTUAL_VERSION}" != "${EXPECTED_VERSION}" ]; then
+            echo "package.json version (${ACTUAL_VERSION}) does not match tag version (${EXPECTED_VERSION})."
+            exit 1
+          fi
+          echo "package.json version is ${ACTUAL_VERSION}."
+
       - name: Build extension package
         run: npm run package
 
@@ -50,12 +67,20 @@ jobs:
       - name: Locate VSIX artifact
         id: package
         shell: bash
+        env:
+          EXPECTED_VERSION: ${{ steps.version.outputs.version }}
         run: |
           VSIX_PATH="$(ls -1 *.vsix | head -n 1)"
           if [ -z "${VSIX_PATH}" ]; then
             echo "VSIX file was not generated."
             exit 1
           fi
+          MANIFEST_VERSION="$(unzip -p "${VSIX_PATH}" extension/package.json | node -p "JSON.parse(require('fs').readFileSync(0,'utf8')).version")"
+          if [ "${MANIFEST_VERSION}" != "${EXPECTED_VERSION}" ]; then
+            echo "VSIX manifest version (${MANIFEST_VERSION}) does not match tag version (${EXPECTED_VERSION})."
+            exit 1
+          fi
+          echo "VSIX manifest version is ${MANIFEST_VERSION}."
           echo "vsix_path=${VSIX_PATH}" >> "${GITHUB_OUTPUT}"
 
       - name: Publish VSIX to GitHub Artifacts

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,68 @@
+# Release & Versioning
+
+The extension version in `package.json` is derived from the git tag that
+triggers a release. You do not need to edit the `version` field by hand for a
+release.
+
+## Tag format
+
+- Tags must use a lowercase `v` prefix followed by a strict
+  [SemVer](https://semver.org/) version, for example `v1.2.3`.
+- Pre-release tags are supported, for example `v1.2.3-beta.1`.
+- An uppercase `V` prefix (e.g. `V1.2.3`) or a missing prefix (e.g. `1.2.3`) is
+  rejected.
+- The leading `v` is stripped to produce the `package.json` version
+  (`v1.2.3` → `1.2.3`).
+
+## Source of truth
+
+The git tag is the source of truth for a release build. During the release
+workflow the version is applied to `package.json` (and `package-lock.json`)
+before anything is built or packaged, then verified against the produced VSIX
+manifest. A mismatch fails the build.
+
+## Cutting a release
+
+1. Make sure the commit you want to release is on `main`.
+2. Create and push a version tag:
+
+   ```sh
+   git tag v1.2.3
+   git push origin v1.2.3
+   ```
+
+3. The `Release VSIX` workflow (triggered by `v*.*.*` tags) will:
+   - sync `package.json` to the tag version,
+   - build and package the extension into a VSIX,
+   - verify the VSIX manifest version matches the tag,
+   - upload the VSIX as a build artifact, and
+   - create a GitHub Release with generated notes and the VSIX attached.
+
+## Local / CI tag-based builds
+
+The default `npm run package` does **not** change the version, so day-to-day
+development is unaffected.
+
+To reproduce a tag-based build locally, sync the version from the latest version
+tag reachable from your current commit, then package:
+
+```sh
+npm run version:from-tag   # applies the latest reachable v* tag to package.json
+npm run package
+npm run vsce:package
+```
+
+- `npm run version:resolve` prints the resolved version without changing files.
+- `npm run version:from-tag` applies it via
+  `npm version --no-git-tag-version --allow-same-version --ignore-scripts`.
+- If no reachable version tag exists, both commands fail with a clear error.
+
+"Latest tag" means the newest `v*` tag reachable from the current commit history
+(discovered with `git tag --list 'v*' --sort=-v:refname --merged HEAD`), not the
+globally newest tag in the repository.
+
+## Implementation
+
+The shared logic lives in [`scripts/tag-version.cjs`](../scripts/tag-version.cjs)
+and is covered by unit tests in
+[`src/test/suite/tagVersion.test.ts`](../src/test/suite/tagVersion.test.ts).

--- a/docs/release_ja.md
+++ b/docs/release_ja.md
@@ -1,0 +1,69 @@
+# リリースとバージョニング
+
+`package.json` の拡張機能バージョンは、リリースのトリガーとなる git タグから
+導出されます。リリースのために `version` フィールドを手動で編集する必要は
+ありません。
+
+## タグ形式
+
+- タグは小文字の `v` 接頭辞と、それに続く厳密な
+  [SemVer](https://semver.org/) バージョンを使用します（例: `v1.2.3`）。
+- プレリリースタグもサポートします（例: `v1.2.3-beta.1`）。
+- 大文字の `V` 接頭辞（例: `V1.2.3`）や接頭辞なし（例: `1.2.3`）は拒否されます。
+- 先頭の `v` は除去され、`package.json` のバージョンになります
+  （`v1.2.3` → `1.2.3`）。
+
+## 信頼できる唯一の情報源（source of truth）
+
+リリースビルドにおいては git タグが信頼できる唯一の情報源です。リリース
+ワークフローでは、ビルドやパッケージ化を行う前にバージョンを `package.json`
+（および `package-lock.json`）へ反映し、その後、生成された VSIX マニフェストと
+照合します。不一致の場合はビルドが失敗します。
+
+## リリース手順
+
+1. リリースしたいコミットが `main` 上にあることを確認します。
+2. バージョンタグを作成してプッシュします。
+
+   ```sh
+   git tag v1.2.3
+   git push origin v1.2.3
+   ```
+
+3. `Release VSIX` ワークフロー（`v*.*.*` タグでトリガー）が以下を実行します。
+   - `package.json` をタグのバージョンに同期、
+   - 拡張機能をビルドして VSIX にパッケージ化、
+   - VSIX マニフェストのバージョンがタグと一致するか検証、
+   - VSIX をビルド成果物としてアップロード、
+   - 生成されたリリースノートと VSIX を添付した GitHub Release を作成。
+
+## ローカル / CI でのタグベースビルド
+
+既定の `npm run package` はバージョンを **変更しません**。そのため通常の
+開発には影響しません。
+
+タグベースのビルドをローカルで再現するには、現在のコミットから到達可能な
+最新のバージョンタグからバージョンを同期し、パッケージ化します。
+
+```sh
+npm run version:from-tag   # 到達可能な最新の v* タグを package.json へ反映
+npm run package
+npm run vsce:package
+```
+
+- `npm run version:resolve` はファイルを変更せず、解決したバージョンを表示します。
+- `npm run version:from-tag` は
+  `npm version --no-git-tag-version --allow-same-version --ignore-scripts`
+  を用いて反映します。
+- 到達可能なバージョンタグが存在しない場合、いずれのコマンドも明確な
+  エラーで失敗します。
+
+「最新のタグ」とは、リポジトリ全体で最も新しいタグではなく、現在のコミット
+履歴から到達可能な最も新しい `v*` タグを指します
+（`git tag --list 'v*' --sort=-v:refname --merged HEAD` で検出）。
+
+## 実装
+
+共有ロジックは [`scripts/tag-version.cjs`](../scripts/tag-version.cjs) にあり、
+[`src/test/suite/tagVersion.test.ts`](../src/test/suite/tagVersion.test.ts) の
+ユニットテストでカバーされています。

--- a/package.json
+++ b/package.json
@@ -287,6 +287,8 @@
     "prepackage": "npm run security:check",
     "package": "npm run compile:types && npm run compile:webview && webpack --mode production --devtool hidden-source-map && npm run bundle:webview:prod",
     "vsce:package": "npx --yes @vscode/vsce@3.9.1 package --no-dependencies",
+    "version:resolve": "node scripts/tag-version.cjs",
+    "version:from-tag": "node scripts/tag-version.cjs --apply",
     "compile-tests": "tsc -p ./tsconfig.test.json",
     "pretest": "npm run compile-tests",
     "test": "mocha --ui tdd --timeout 10000 \"out-test/src/test/suite/**/*.test.js\"",

--- a/scripts/tag-version.cjs
+++ b/scripts/tag-version.cjs
@@ -1,0 +1,250 @@
+'use strict';
+
+// Resolve the extension version from a git tag and (optionally) apply it to
+// package.json. The git tag is the source of truth for release builds.
+//
+// Accepted tag format: a lowercase `v` prefix followed by a strict SemVer
+// version (e.g. `v1.2.3`, `v1.2.3-beta.1`). The `v` is stripped to produce the
+// package.json version. Uppercase `V`, a missing prefix, or non-SemVer values
+// are rejected.
+//
+// This file is intentionally a dependency-free CommonJS module so it can run
+// before the build (no TypeScript/ts-node bootstrapping) and be unit-tested by
+// the existing Mocha suite via `require`.
+
+const { execFileSync } = require('child_process');
+
+// Official SemVer 2.0.0 pattern (without the leading `v`).
+const SEMVER =
+  /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/;
+
+const REFS_TAGS_PREFIX = 'refs/tags/';
+
+/**
+ * Remove a leading `refs/tags/` ref prefix if present.
+ * @param {string} value
+ * @returns {string}
+ */
+function stripRefsPrefix(value) {
+  if (value.startsWith(REFS_TAGS_PREFIX)) {
+    return value.slice(REFS_TAGS_PREFIX.length);
+  }
+  return value;
+}
+
+/**
+ * @param {string} version
+ * @returns {boolean}
+ */
+function isValidVersion(version) {
+  return typeof version === 'string' && SEMVER.test(version);
+}
+
+/**
+ * Normalize a raw tag value (optionally `refs/tags/`-prefixed) into a strict
+ * SemVer version string. Throws on any value that is not a lowercase
+ * `v`-prefixed SemVer tag.
+ * @param {string} rawTag
+ * @returns {string}
+ */
+function normalizeTag(rawTag) {
+  if (typeof rawTag !== 'string' || rawTag.trim() === '') {
+    throw new Error('No tag value was provided to normalize.');
+  }
+
+  const tag = stripRefsPrefix(rawTag.trim());
+
+  if (tag.startsWith('V')) {
+    throw new Error(
+      `Invalid tag "${tag}": the version prefix must be a lowercase "v" (uppercase "V" is not allowed).`
+    );
+  }
+
+  if (!tag.startsWith('v')) {
+    throw new Error(
+      `Invalid tag "${tag}": tags must start with a lowercase "v" prefix (e.g. "v1.2.3").`
+    );
+  }
+
+  const version = tag.slice(1);
+
+  if (!isValidVersion(version)) {
+    throw new Error(
+      `Invalid tag "${tag}": "${version}" is not a valid SemVer version (expected e.g. "v1.2.3" or "v1.2.3-beta.1").`
+    );
+  }
+
+  return version;
+}
+
+/**
+ * Pick the tag reference from the environment, preferring `GITHUB_REF_NAME`
+ * (the tag name on a tag push) and falling back to `GITHUB_REF`.
+ * @param {NodeJS.ProcessEnv} env
+ * @returns {string | null}
+ */
+function resolveTagFromEnv(env) {
+  const refName = env.GITHUB_REF_NAME;
+  if (typeof refName === 'string' && refName.trim() !== '') {
+    return refName.trim();
+  }
+
+  const ref = env.GITHUB_REF;
+  if (typeof ref === 'string' && ref.startsWith(REFS_TAGS_PREFIX)) {
+    return stripRefsPrefix(ref).trim();
+  }
+
+  return null;
+}
+
+/**
+ * Discover the latest version tag reachable from HEAD. Only `v*` tags are
+ * considered, sorted by descending SemVer-aware version order, so unrelated
+ * tags (e.g. `docs-update`) never shadow a real release tag.
+ * @param {(file: string, args: string[]) => string} exec
+ * @returns {string | null}
+ */
+function resolveLatestReachableTag(exec) {
+  const output = exec('git', [
+    'tag',
+    '--list',
+    'v*',
+    '--sort=-v:refname',
+    '--merged',
+    'HEAD'
+  ]);
+
+  const firstTag = output
+    .split('\n')
+    .map(line => line.trim())
+    .find(line => line !== '');
+
+  return firstTag ?? null;
+}
+
+/**
+ * @param {string} file
+ * @param {string[]} args
+ * @returns {string}
+ */
+function defaultExec(file, args) {
+  return execFileSync(file, args, { encoding: 'utf8' });
+}
+
+/**
+ * Resolve the normalized version from a tag.
+ *
+ * @param {object} [options]
+ * @param {NodeJS.ProcessEnv} [options.env] Environment to read tag refs from.
+ * @param {boolean} [options.requireEnv] When true, only the environment tag is
+ *   used (no local git fallback). Intended for release CI.
+ * @param {(file: string, args: string[]) => string} [options.exec] git runner.
+ * @returns {string} The normalized SemVer version (no `v` prefix).
+ */
+function resolveVersion(options) {
+  const opts = options ?? {};
+  const env = opts.env ?? process.env;
+  const requireEnv = opts.requireEnv ?? false;
+  const exec = opts.exec ?? defaultExec;
+
+  const envTag = resolveTagFromEnv(env);
+  if (envTag !== null) {
+    return normalizeTag(envTag);
+  }
+
+  if (requireEnv) {
+    throw new Error(
+      'No tag ref found in the environment (GITHUB_REF_NAME / GITHUB_REF). ' +
+        'This command must run on a tag push.'
+    );
+  }
+
+  const latestTag = resolveLatestReachableTag(exec);
+  if (latestTag === null) {
+    throw new Error(
+      'No reachable version tag (v*) was found from HEAD. ' +
+        'Create a tag like "v1.2.3" before building from a tag.'
+    );
+  }
+
+  return normalizeTag(latestTag);
+}
+
+/**
+ * Apply the resolved version to package.json (and package-lock.json) using npm,
+ * without creating a git tag/commit and without running lifecycle scripts.
+ * @param {string} version
+ * @param {(file: string, args: string[]) => void} [run]
+ */
+function applyVersion(version, run) {
+  if (!isValidVersion(version)) {
+    throw new Error(`Refusing to apply invalid version "${version}".`);
+  }
+
+  const npm = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+  const exec =
+    run ??
+    ((file, args) => {
+      execFileSync(file, args, { stdio: 'inherit' });
+    });
+
+  exec(npm, [
+    'version',
+    '--no-git-tag-version',
+    '--allow-same-version',
+    '--ignore-scripts',
+    version
+  ]);
+}
+
+function parseArgs(argv) {
+  return {
+    apply: argv.includes('--apply'),
+    requireEnv: argv.includes('--require-env'),
+    writeGithubOutput: argv.includes('--write-github-output')
+  };
+}
+
+function main(argv) {
+  const args = parseArgs(argv);
+
+  let version;
+  try {
+    version = resolveVersion({ requireEnv: args.requireEnv });
+  } catch (error) {
+    process.stderr.write(
+      `tag-version: ${error instanceof Error ? error.message : String(error)}\n`
+    );
+    process.exit(1);
+    return;
+  }
+
+  if (args.apply) {
+    applyVersion(version);
+  }
+
+  if (args.writeGithubOutput && process.env.GITHUB_OUTPUT) {
+    require('fs').appendFileSync(
+      process.env.GITHUB_OUTPUT,
+      `version=${version}\n`
+    );
+  }
+
+  process.stdout.write(`${version}\n`);
+}
+
+module.exports = {
+  SEMVER,
+  stripRefsPrefix,
+  isValidVersion,
+  normalizeTag,
+  resolveTagFromEnv,
+  resolveLatestReachableTag,
+  resolveVersion,
+  applyVersion,
+  parseArgs
+};
+
+if (require.main === module) {
+  main(process.argv.slice(2));
+}

--- a/scripts/tag-version.cjs
+++ b/scripts/tag-version.cjs
@@ -114,12 +114,22 @@ function resolveLatestReachableTag(exec) {
     'HEAD'
   ]);
 
-  const firstTag = output
+  const latestVersionTag = output
     .split('\n')
     .map(line => line.trim())
-    .find(line => line !== '');
+    .find(line => {
+      if (line === '') {
+        return false;
+      }
+      try {
+        normalizeTag(line);
+        return true;
+      } catch {
+        return false;
+      }
+    });
 
-  return firstTag ?? null;
+  return latestVersionTag ?? null;
 }
 
 /**

--- a/src/test/suite/tagVersion.test.ts
+++ b/src/test/suite/tagVersion.test.ts
@@ -135,6 +135,14 @@ suite('Tag version resolver', () => {
     assert.equal(latest, 'v1.4.0');
   });
 
+  test('skips non-version v-prefixed tags during fallback discovery', () => {
+    const version = tagVersion.resolveVersion({
+      env: {} as NodeJS.ProcessEnv,
+      exec: () => 'vlatest\nv1.2.3\n'
+    });
+    assert.equal(version, '1.2.3');
+  });
+
   test('applies the version with the safe npm flags and both files in scope', () => {
     const calls: Array<{ file: string; args: string[] }> = [];
     tagVersion.applyVersion('3.1.4', (file, args) => {

--- a/src/test/suite/tagVersion.test.ts
+++ b/src/test/suite/tagVersion.test.ts
@@ -1,0 +1,171 @@
+import { strict as assert } from 'assert';
+import * as path from 'path';
+
+// The resolver is a dependency-free CommonJS module that also powers the
+// release workflow, so it is loaded here via require to exercise the exact same
+// code path that CI runs.
+/* eslint-disable @typescript-eslint/no-require-imports */
+const tagVersion = require(path.resolve(__dirname, '../../../../scripts/tag-version.cjs')) as {
+  normalizeTag(rawTag: string): string;
+  isValidVersion(version: string): boolean;
+  stripRefsPrefix(value: string): string;
+  resolveTagFromEnv(env: NodeJS.ProcessEnv): string | null;
+  resolveLatestReachableTag(exec: (file: string, args: string[]) => string): string | null;
+  resolveVersion(options?: {
+    env?: NodeJS.ProcessEnv;
+    requireEnv?: boolean;
+    exec?: (file: string, args: string[]) => string;
+  }): string;
+  applyVersion(version: string, run?: (file: string, args: string[]) => void): void;
+  parseArgs(argv: string[]): { apply: boolean; requireEnv: boolean; writeGithubOutput: boolean };
+};
+
+suite('Tag version resolver', () => {
+  test('normalizes a plain v-prefixed tag', () => {
+    assert.equal(tagVersion.normalizeTag('v1.2.3'), '1.2.3');
+  });
+
+  test('normalizes a refs/tags/ prefixed tag', () => {
+    assert.equal(tagVersion.normalizeTag('refs/tags/v1.2.3'), '1.2.3');
+  });
+
+  test('normalizes a pre-release tag', () => {
+    assert.equal(tagVersion.normalizeTag('v1.2.3-beta.1'), '1.2.3-beta.1');
+  });
+
+  test('trims surrounding whitespace before normalizing', () => {
+    assert.equal(tagVersion.normalizeTag('  v1.2.3  '), '1.2.3');
+  });
+
+  test('rejects an uppercase V prefix', () => {
+    assert.throws(() => tagVersion.normalizeTag('V1.2.3'), /lowercase "v"/);
+  });
+
+  test('rejects a tag without a v prefix', () => {
+    assert.throws(() => tagVersion.normalizeTag('1.2.3'), /lowercase "v" prefix/);
+  });
+
+  test('rejects a non-version tag', () => {
+    assert.throws(() => tagVersion.normalizeTag('vlatest'), /not a valid SemVer/);
+  });
+
+  test('rejects an empty tag', () => {
+    assert.throws(() => tagVersion.normalizeTag(''), /No tag value/);
+  });
+
+  test('validates SemVer versions', () => {
+    assert.equal(tagVersion.isValidVersion('1.2.3'), true);
+    assert.equal(tagVersion.isValidVersion('1.2.3-beta.1'), true);
+    assert.equal(tagVersion.isValidVersion('1.2'), false);
+    assert.equal(tagVersion.isValidVersion('v1.2.3'), false);
+  });
+
+  test('reads the tag from GITHUB_REF_NAME first', () => {
+    const tag = tagVersion.resolveTagFromEnv({ GITHUB_REF_NAME: 'v1.2.3' } as NodeJS.ProcessEnv);
+    assert.equal(tag, 'v1.2.3');
+  });
+
+  test('falls back to GITHUB_REF when it points at a tag', () => {
+    const tag = tagVersion.resolveTagFromEnv({
+      GITHUB_REF: 'refs/tags/v1.2.3'
+    } as NodeJS.ProcessEnv);
+    assert.equal(tag, 'v1.2.3');
+  });
+
+  test('ignores GITHUB_REF when it points at a branch', () => {
+    const tag = tagVersion.resolveTagFromEnv({
+      GITHUB_REF: 'refs/heads/main'
+    } as NodeJS.ProcessEnv);
+    assert.equal(tag, null);
+  });
+
+  test('returns null when no tag ref is present', () => {
+    assert.equal(tagVersion.resolveTagFromEnv({} as NodeJS.ProcessEnv), null);
+  });
+
+  test('resolves the version from the environment tag', () => {
+    const version = tagVersion.resolveVersion({
+      env: { GITHUB_REF_NAME: 'v2.0.0' } as NodeJS.ProcessEnv,
+      exec: () => {
+        throw new Error('git should not be called when an env tag is present');
+      }
+    });
+    assert.equal(version, '2.0.0');
+  });
+
+  test('requireEnv fails when no environment tag is present', () => {
+    assert.throws(
+      () =>
+        tagVersion.resolveVersion({
+          env: {} as NodeJS.ProcessEnv,
+          requireEnv: true,
+          exec: () => {
+            throw new Error('git should not be called in requireEnv mode');
+          }
+        }),
+      /must run on a tag push/
+    );
+  });
+
+  test('falls back to the latest reachable version tag', () => {
+    const version = tagVersion.resolveVersion({
+      env: {} as NodeJS.ProcessEnv,
+      exec: (file, args) => {
+        assert.equal(file, 'git');
+        assert.deepEqual(args, ['tag', '--list', 'v*', '--sort=-v:refname', '--merged', 'HEAD']);
+        return 'v0.9.0\nv0.8.0\n';
+      }
+    });
+    assert.equal(version, '0.9.0');
+  });
+
+  test('fails when no reachable version tag exists', () => {
+    assert.throws(
+      () =>
+        tagVersion.resolveVersion({
+          env: {} as NodeJS.ProcessEnv,
+          exec: () => ''
+        }),
+      /No reachable version tag/
+    );
+  });
+
+  test('only considers v-prefixed tags during fallback discovery', () => {
+    const latest = tagVersion.resolveLatestReachableTag(() => 'v1.4.0\n');
+    assert.equal(latest, 'v1.4.0');
+  });
+
+  test('applies the version with the safe npm flags and both files in scope', () => {
+    const calls: Array<{ file: string; args: string[] }> = [];
+    tagVersion.applyVersion('3.1.4', (file, args) => {
+      calls.push({ file, args });
+    });
+
+    assert.equal(calls.length, 1);
+    assert.match(calls[0].file, /^npm(\.cmd)?$/);
+    assert.deepEqual(calls[0].args, [
+      'version',
+      '--no-git-tag-version',
+      '--allow-same-version',
+      '--ignore-scripts',
+      '3.1.4'
+    ]);
+  });
+
+  test('refuses to apply an invalid version', () => {
+    assert.throws(() => tagVersion.applyVersion('not-a-version', () => undefined), /invalid version/);
+  });
+
+  test('parses CLI flags', () => {
+    assert.deepEqual(tagVersion.parseArgs(['--apply', '--require-env', '--write-github-output']), {
+      apply: true,
+      requireEnv: true,
+      writeGithubOutput: true
+    });
+    assert.deepEqual(tagVersion.parseArgs([]), {
+      apply: false,
+      requireEnv: false,
+      writeGithubOutput: false
+    });
+  });
+});


### PR DESCRIPTION
Closes #103

## Summary
Make the extension version derive automatically from git tags (lowercase `v` prefix stripped), for both the tag-triggered release CI and explicit local/CI tag-based builds.

## Changes
- **`scripts/tag-version.cjs`** — new dependency-free CommonJS resolver. Reads tag candidates from `GITHUB_REF_NAME` / `GITHUB_REF`, falls back to the latest reachable version tag (`git tag --list 'v*' --sort=-v:refname --merged HEAD`), normalizes `vX.Y.Z` → `X.Y.Z` (lowercase `v` only, uppercase `V` rejected), validates strict SemVer including pre-release, and applies the version with `npm version --no-git-tag-version --allow-same-version --ignore-scripts` (rewrites both `package.json` and `package-lock.json`).
- **`.github/workflows/release-vsix.yml`** — trigger tightened from `'*'` to `'v*.*.*'`; syncs the version from the pushed tag before building, verifies `package.json` matches, and verifies the embedded VSIX manifest version after packaging.
- **`package.json`** — new `version:resolve` and `version:from-tag` scripts. Default `npm run package` is unchanged.
- **Tests** — `src/test/suite/tagVersion.test.ts` adds 21 regression tests (parsing, validation, env precedence, fallback discovery, safe apply flags, CLI flags).
- **Docs** — `docs/release.md` + `docs/release_ja.md`.

## Validation
- `npm run compile` ✅
- `npm run lint` ✅
- `npm test` ✅ (265 passing, incl. 21 new)
- `npm run security:check` ✅ (0 vulnerabilities)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>