### PR TITLE
Exclude Japanese docs (*_ja.md) from the packaged VSIX

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -24,6 +24,9 @@ tsconfig.webview.json
 .gitignore
 .nvmrc
 
+# Japanese-version docs (kept in the repo, not shipped in the VSIX)
+**/*_ja.md
+
 # Artifacts not required in VSIX runtime
 out/**
 **/*.ts


### PR DESCRIPTION
## Summary
Exclude Japanese-version documentation files (`*_ja.md`) from the packaged VSIX.

## Changes
- Add `**/*_ja.md` ignore pattern to `.vscodeignore`.

## Background
- VS Code has **no native feature** to auto-display localized README/documentation based on the display language. The extension details page always renders the root `README.md`; `.nls.json` / `vscode.l10n` localization only covers UI strings, not documentation. So bundling `_ja.md` files serves no purpose inside the package.
- Before: `vsce ls` showed `SECURITY_ja.md` bundled. After: only `README.md` and `SECURITY.md` remain. `docs/**` was already excluded.
- Japanese docs remain available in the GitHub repository.

## Validation
- `npm run compile` ✅
- `npm run lint` ✅
- `npm test` ✅ (266 passing)
- `npm run security:check` ✅ (0 vulnerabilities)
- `vsce ls --no-dependencies` confirms no `*_ja.md` is packaged ✅

Closes #105